### PR TITLE
add props to conrol expansion on main panel and panel sections state

### DIFF
--- a/src/wrappers/components/ui/FilterPanelWrapper.svelte
+++ b/src/wrappers/components/ui/FilterPanelWrapper.svelte
@@ -184,6 +184,7 @@
             id: "document-type",
             type: "radios",
             title: "Document type",
+            openByDefault: true,
             ga4Section: "document_type",
             ga4IndexSection: 1,
             ga4IndexSectionCount: 4,
@@ -279,6 +280,36 @@
           markdown: true,
           arr: [
             "The text to display on the apply button at the bottom of the filter panel.",
+          ],
+        },
+      },
+      {
+        name: "filterPanelSectionsExpanded",
+        category: "Display props",
+        value: false,
+        options: [true, false],
+        propType: "radio",
+        description: {
+          markdown: true,
+          arr: [
+            "Controls whether individual filter sections (like 'Document type', 'Date published') are expanded or collapsed.",
+            "This works reactively - changing the value will immediately expand/collapse all sections.",
+            "Individual sections can override this setting using their `openByDefault` property.",
+          ],
+        },
+      },
+      {
+        name: "filterPanelExpanded",
+        category: "Display props",
+        value: true,
+        options: [true, false],
+        propType: "radio",
+        description: {
+          markdown: true,
+          arr: [
+            "Controls whether the entire filter panel is visible or hidden.",
+            "This works reactively - changing the value will immediately show/hide the filter panel.",
+            "When `false`, users need to click the 'Filter and sort' button to reveal the filter options.",
           ],
         },
       },


### PR DESCRIPTION
## PR: Add External Control for Filter Panel Expansion State

### Overview

This PR introduces two new props to the FilterPanel component to enable external control over the expansion state of both the entire filter panel and its individual sections. These changes make the component more flexible and easier to integrate in different contexts, while also improving documentation and prop configurability.

### Key Changes

#### `src/lib/components/ui/FilterPanel.svelte`

- Added two new props:
  - `filterPanelSectionsExpanded` (default: `false`): Controls whether individual filter sections are expanded or collapsed by default. Can be overridden per-section using the `openByDefault` property.
  - `filterPanelExpanded` (default: `true`): Controls whether the whole filter panel is visible.
- Switched the internal `panelOpen` state to derive from `filterPanelExpanded` for more reactive control.
- Modified the logic for section expansion to respect `filterPanelSectionsExpanded` unless explicitly overridden.
- Wrapped the filter panel markup in a Svelte `{#key ...}` block to force re-render when expansion props change, ensuring UI sync.
- Minor code formatting and comment updates.

#### `src/wrappers/components/ui/FilterPanelWrapper.svelte`

- Set `openByDefault: true` for the "Document type" section for demonstration.
- Added prop definitions for `filterPanelSectionsExpanded` and `filterPanelExpanded` to the prop panel, both with toggleable options and clear documentation/descriptions.

### Motivation

- Enables parent components or Storybook controls to externally manage the expansion state of the filter panel and its sections, which is useful for demos, testing, and advanced UI interactions.
- Improves the documentation and discoverability of these options for users of the component library.

### How to Test

- Use the prop controls in the wrapper to toggle `filterPanelSectionsExpanded` and `filterPanelExpanded` and verify the UI updates accordingly.
- Check that setting `openByDefault` on a section still takes precedence over the global `filterPanelSectionsExpanded` prop.