### PR TITLE
Add text color prop and force color change with css variable

### DIFF
--- a/src/lib/components/ui/Masthead.svelte
+++ b/src/lib/components/ui/Masthead.svelte
@@ -255,7 +255,7 @@
     color: var(
       --masthead-text-color,
       #ffffff
-    ); /* Override to white for masthead */
+    ); /* Override to textColor prop if specified otherwise fall back to white */
     font-family: "GDS Transport", arial, sans-serif;
     font-weight: 700;
     font-size: 2rem;

--- a/src/lib/components/ui/Masthead.svelte
+++ b/src/lib/components/ui/Masthead.svelte
@@ -11,6 +11,7 @@
     imageSrc = homepageIllustration,
     imageAlt = "",
     backgroundColor = "#1d70b8", // GOV.UK blue by default
+    textColor = "#FFFFFF",
   } = $props<{
     title?: string;
     description?: string;
@@ -20,12 +21,13 @@
     imageSrc?: string;
     imageAlt?: string;
     backgroundColor?: string;
+    textColor?: string;
   }>();
 </script>
 
 <div
   class="app-masthead"
-  style="background-color: {backgroundColor}; border-bottom-color: {backgroundColor};"
+  style="background-color: {backgroundColor}; border-bottom-color: {backgroundColor}; --masthead-text-color: {textColor};"
 >
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
@@ -250,7 +252,10 @@
 
   /* GOV.UK Typography - Scoped to our component with high specificity */
   .app-masthead .govuk-heading-xl.govuk-heading-xl {
-    color: #ffffff; /* Override to white for masthead */
+    color: var(
+      --masthead-text-color,
+      #ffffff
+    ); /* Override to white for masthead */
     font-family: "GDS Transport", arial, sans-serif;
     font-weight: 700;
     font-size: 2rem;
@@ -266,5 +271,9 @@
       line-height: 1.04167;
       margin-bottom: 3.125rem;
     }
+  }
+
+  .app-masthead__description {
+    color: var(--masthead-text-color);
   }
 </style>

--- a/src/wrappers/components/ui/MastheadWrapper.svelte
+++ b/src/wrappers/components/ui/MastheadWrapper.svelte
@@ -211,7 +211,7 @@
       },
       {
         name: "textColor",
-        category: "Content",
+        category: "Visual",
         value: "#FFFFFF",
         description: {
           markdown: true,

--- a/src/wrappers/components/ui/MastheadWrapper.svelte
+++ b/src/wrappers/components/ui/MastheadWrapper.svelte
@@ -210,6 +210,15 @@
         rows: 4,
       },
       {
+        name: "textColor",
+        category: "Content",
+        value: "#FFFFFF",
+        description: {
+          markdown: true,
+          arr: ["The text color of the title and description."],
+        },
+      },
+      {
         name: "includeButton",
         category: "Call to Action",
         value: true,


### PR DESCRIPTION
I'm using the mast head component in the deprivation app. I want to make the text black instead of white so I added a text color prop to this component.

At first it only made the description text black. The title stayed white because of a high specificity css selector setting it to white. I introduced a css variable for text color and made that et priority. If no text color is chosen it falls back to white.