### PR TITLE
Feature/multi select disable suggestion options for already selected parent value|id2 65

### DIFF
--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -432,6 +432,19 @@
     removeItemButton !== undefined ? removeItemButton : multiple,
   );
 
+  // Computed form group classes with optional full width override
+  let computedFormGroupClasses = $derived.by(() => {
+    if (fullWidth) {
+      // Remove existing width classes and add w-full
+      const withoutWidthClasses = formGroupClasses
+        .split(' ')
+        .filter(cls => !cls.startsWith('w-') && !cls.startsWith('max-w-') && !cls.startsWith('min-w-'))
+        .join(' ');
+      return `${withoutWidthClasses} w-full`.trim();
+    }
+    return formGroupClasses;
+  });
+
   // Enhanced items with placeholder for single select
   let enhancedItems = $derived.by(() => {
     if (multiple) return items;
@@ -2570,7 +2583,7 @@
     {hint}
     {error}
     {validate}
-    {formGroupClasses}
+    formGroupClasses={computedFormGroupClasses}
     {fullWidth}
     {describedBy}
     {disabled}

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -76,6 +76,9 @@
     choicesItemBorderColor = "#b1b4b6",
     choicesItemTextColor = "black",
     choicesItemDividerPadding = "10px",
+    choicesItemBorderRadius = "0",
+    // Selected chip/pill specific styling
+    selectedChipBackgroundColor = "#f3f2f1",
     // Circle feature props
     enableSelectedItemCircles = true,
     selectedItemCircleColor = "#1d70b8", // Default color when not using palette
@@ -100,7 +103,9 @@
       "#626a6e", // Mid grey
       "#b1b4b6", // Light grey
       "#0b0c0c", // Black
-    ], // Complete GOV.UK Design System palette (19 colors)
+    ],
+    // Enable border colors to match circle colors for selected items
+    matchBorderToCircleColor = false,
 
     // Cross-selection relationship resolvers (optional)
     // If provided, they enable dynamic messages when results map to already-selected parents/children
@@ -173,9 +178,12 @@
     choicesItemBorderColor?: string;
     choicesItemTextColor?: string;
     choicesItemDividerPadding?: string;
+    choicesItemBorderRadius?: string;
+    selectedChipBackgroundColor?: string;
     enableSelectedItemCircles?: boolean;
     selectedItemCircleColor?: string;
     selectedItemCircleColorPalette?: string[];
+    matchBorderToCircleColor?: boolean;
 
     // Cross-selection relationship resolvers (optional)
     apiParentResolver?:
@@ -1206,10 +1214,12 @@
               const meta = (data as any)?.customProperties;
               const hasParent = meta && meta.parentValue && meta.parentLabel;
 
+              // Color calculation (needed for both circles and border matching)
+              let color = "#b1b4b6"; // Default fallback color
+              
               // Circle (color keyed by parent if present, else extract parent from composite value)
-              let circle = "";
+              let colorKey;
               if (enableSelectedItemCircles && isMulti) {
-                let colorKey;
                 if (hasParent) {
                   colorKey = meta.parentValue;
                 } else if (String(data.value).includes("::")) {
@@ -1218,7 +1228,12 @@
                 } else {
                   colorKey = data.value;
                 }
-                const color = colorForValue(colorKey);
+                color = colorForValue(colorKey);
+              }
+
+              // Circle 
+              let circle = "";
+              if (enableSelectedItemCircles && isMulti) {
                 circle = `<span class="choices__item-circle" style="background:${color}"></span>`;
               }
 
@@ -1240,6 +1255,11 @@
                            aria-label="Remove ${esc(String(data.value))}"></button>`
                 : "";
 
+              // Border styling for matching circle color
+              const borderStyle = matchBorderToCircleColor && enableSelectedItemCircles && isMulti 
+                ? `style="border: 2px solid ${color}; box-shadow: none;"` 
+                : "";
+
               return strToEl(
                 `<div class="${classes}"
                       data-item
@@ -1247,7 +1267,8 @@
                       data-value="${String(data.value)}"
                       ${showRemove ? "data-deletable" : ""}
                       ${data.active ? 'aria-selected="true"' : ""}
-                      ${data.disabled ? 'aria-disabled="true"' : ""}>
+                      ${data.disabled ? 'aria-disabled="true"' : ""}
+                      ${borderStyle}>
                     ${circle}${displayLabel}${removeBtn}
                  </div>`,
               );
@@ -2513,10 +2534,11 @@
 
 <div
   class="gem-c-select-with-search"
-  style={`--cross-icon-url: url("${crossIconUrl}"); --choices-item-bg-color: ${choicesItemBackgroundColor}; --choices-item-border-color: ${choicesItemBorderColor}; --choices-item-text-color: ${choicesItemTextColor}; --choices-item-divider-padding: ${choicesItemDividerPadding}; --selected-item-circle-color: ${selectedItemCircleColor};`}
+  style={`--cross-icon-url: url("${crossIconUrl}"); --choices-item-bg-color: ${choicesItemBackgroundColor}; --choices-item-border-color: ${choicesItemBorderColor}; --choices-item-text-color: ${choicesItemTextColor}; --choices-item-divider-padding: ${choicesItemDividerPadding}; --choices-item-border-radius: ${choicesItemBorderRadius}; --selected-chip-bg-color: ${selectedChipBackgroundColor}; --selected-item-circle-color: ${selectedItemCircleColor};`}
   data-group-key={groupKey}
   data-enable-circles={enableSelectedItemCircles}
   data-circle-palette={selectedItemCircleColorPalette.join(",")}
+  data-match-border-to-circle={matchBorderToCircleColor}
 >
   {#snippet rightIcon()}
     <button
@@ -3394,10 +3416,11 @@
     border: 0;
     padding: 0 0px 0 10px; /* right padding for button divider */
     margin: 10px 10px 0 0;
-    background-color: #f3f2f1;
-    box-shadow: 0 2px 0 #b1b4b6;
+    background-color: var(--selected-chip-bg-color, #f3f2f1);
+    box-shadow: 0 2px 0 var(--choices-item-border-color, #b1b4b6);
+    border-radius: var(--choices-item-border-radius, 0);
     line-height: 1;
-    color: #0b0c0c;
+    color: var(--choices-item-text-color, #0b0c0c);
   }
 
   /* Circle */

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -1822,10 +1822,7 @@
                             const parentLabel =
                               first.parent.label ?? String(first.parent.value);
                             choicesInstance.config.noChoicesText =
-                              tPartialPostcodeInSelectedParent(
-                                q,
-                                parentLabel,
-                              );
+                              tPartialPostcodeInSelectedParent(q, parentLabel);
                             usedResolverMessage = true;
                             console.log(
                               "ℹ️ Partial postcode in selected parent (promotion mode)",
@@ -2242,7 +2239,8 @@
                       console.warn("⚠️ staticChildrenResolver failed:", err);
                     }
                     if (!usedDynamic) {
-                      choicesInstance.config.noChoicesText = "All results are already selected";
+                      choicesInstance.config.noChoicesText =
+                        "All results are already selected";
                     }
                     console.log(
                       "ℹ️ Found static matches but all are already selected",

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -1418,27 +1418,6 @@
       selectElement.addEventListener("choice", (ev: any) => {
         console.log("🎯 Choice selected, resetting search");
 
-        // Check if this was a promoted choice and store context
-        const choice = ev?.detail?.choice;
-        if (
-          choice?.customProperties?.isPromoted &&
-          choice.customProperties.parentValue &&
-          choice.customProperties.childLabel
-        ) {
-          const parentValue = choice.customProperties.parentValue;
-          const childLabel = choice.customProperties.childLabel;
-          const parentLabel = choice.customProperties.parentLabel || undefined;
-          const context = `(containing ${childLabel})`;
-          promotedItemContext.set(parentValue, context);
-          if (parentLabel) promotedParentLabelMap.set(parentValue, parentLabel);
-          console.log("🏷️ Stored promotion context:", {
-            parentValue,
-            childLabel,
-            context,
-            parentLabel,
-          });
-        }
-
         // When an item is selected, clear the search and show all unselected options
         if (searchInputElement) {
           searchInputElement.value = "";

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -220,7 +220,9 @@
   let choicesInstance: any;
   let searchInputElement: HTMLInputElement | null = null;
   let debounceTimer: any = null;
+  let lastQuery = "";
   const baseNoChoicesText = "No choices to choose from";
+  let isProcessingPromotion = false;
 
   // Track context for promoted items (postcode -> LAD promotions)
   const promotedItemContext = $state(new Map<string, string>());
@@ -592,7 +594,33 @@
       choicesInstance.config.searchChoices = false;
 
       if (hasStatic) {
-        resetToStaticChoices(); // ensure full dataset is present with group text
+        // For grouped options, use grouped restoration method
+        console.log("🔍 Checking for grouped options:", {
+          groups: groups?.length || 0,
+          hasGroups: !!(groups && groups.length > 0),
+        });
+        if (groups && groups.length > 0) {
+          console.log("📋 Applying grouped options mode");
+          let selectedValues: string[] = [];
+          try {
+            const currentValue = choicesInstance.getValue(true);
+            if (Array.isArray(currentValue)) {
+              selectedValues = currentValue.map((item: any) =>
+                String(item.value || item),
+              );
+            } else if (currentValue && typeof currentValue === "object") {
+              selectedValues = [String(currentValue.value || currentValue)];
+            } else if (currentValue) {
+              selectedValues = [String(currentValue)];
+            }
+          } catch (error) {
+            console.warn("⚠️ Error getting current value:", error);
+            selectedValues = [];
+          }
+          restoreGroupedChoicesWithoutReinit(selectedValues);
+        } else {
+          resetToStaticChoices(); // ensure full dataset is present with group text
+        }
         // Don't set noChoicesText here - let the search logic handle it
         // This allows us to show "No results found" vs "No choices to choose from"
       } else {
@@ -612,7 +640,30 @@
     // Force refresh to show the message
   }
 
-  // selectSource removed (decideMode handles mode selection)
+  // Default selection logic between API and static options
+  function selectSource(query: string): "api" | "options" {
+    if (typeof sourceSelector === "function") {
+      try {
+        return sourceSelector(query, staticPlainOptions);
+      } catch {
+        // fall through to default
+      }
+    }
+
+    // Check if we have static options (items or groups with choices)
+    const hasStaticOptions =
+      (items && items.length > 0) ||
+      (groups && groups.some((g) => g.choices && g.choices.length > 0));
+
+    // If we have static options, use them; otherwise default to API if configured
+    if (hasStaticOptions) {
+      return "options";
+    } else if (source_url && source_key && query.trim().length >= minLength) {
+      return "api";
+    } else {
+      return "options"; // fallback to options even if empty
+    }
+  }
 
   // Build URL for API requests. Replaces {query} placeholder or appends ?q=
   function buildApiUrl(query: string): string {
@@ -640,7 +691,11 @@
     }
   }
 
-  // toValue removed (no longer used)
+  function toValue(o: any, label: string): string | number {
+    if (o && typeof o === "object" && "value" in o && o.value != null)
+      return o.value as string | number;
+    return label;
+  }
 
   async function fetchApiChoices(query: string): Promise<ChoiceItem[]> {
     const url = buildApiUrl(query);
@@ -851,16 +906,11 @@
           // Store reference on the element for external access
           (selectElement as any).choices = choicesInstance;
 
-          // Re-apply the current mode after reinitialization
-          setTimeout(() => {
-            if (choicesInstance) {
-              applyMode(currentMode);
-              console.log(
-                "🔄 Re-applied current mode after reinitialization:",
-                currentMode,
-              );
-            }
-          }, 0);
+          // For grouped options, don't re-apply mode as it would overwrite the grouped structure
+          // The grouped structure is already restored above
+          console.log(
+            "✅ Grouped structure restored, skipping mode re-application",
+          );
 
           // Restore focus to the main Choices container after reinitialization
           setTimeout(() => {
@@ -1144,8 +1194,11 @@
         ? baseNoChoicesText
         : tTooShort(minLength);
 
+      const hasApiConfig = source_url && source_key;
+
       console.log("📊 Initial configuration:", {
         hasStaticOptions,
+        hasApiConfig,
         initialNoChoicesText,
         staticChoices: staticChoices.length,
         enhancedItems: enhancedItems.length,
@@ -1374,8 +1427,15 @@
         config: choicesInstance.config,
       });
 
-      // Initialize static choices
-      choicesInstance.setChoices(staticChoices, "value", "label", true);
+      // Initialize static choices - skip for grouped options as they'll be handled by applyMode
+      if (!(groups && groups.length > 0)) {
+        choicesInstance.setChoices(staticChoices, "value", "label", true);
+        console.log("✅ Initialized with flat static choices");
+      } else {
+        console.log(
+          "⏭️ Skipping initial static choices setup for grouped options",
+        );
+      }
 
       // Keep the bound value in sync by reading from the Choices instance
       selectElement.addEventListener("change", async (_event: Event) => {
@@ -1386,9 +1446,31 @@
       selectElement.addEventListener("choice", (ev: any) => {
         console.log("🎯 Choice selected, resetting search");
 
+        // Check if this was a promoted choice and store context
+        const choice = ev?.detail?.choice;
+        if (
+          choice?.customProperties?.isPromoted &&
+          choice.customProperties.parentValue &&
+          choice.customProperties.childLabel
+        ) {
+          const parentValue = choice.customProperties.parentValue;
+          const childLabel = choice.customProperties.childLabel;
+          const parentLabel = choice.customProperties.parentLabel || undefined;
+          const context = `(containing ${childLabel})`;
+          promotedItemContext.set(parentValue, context);
+          if (parentLabel) promotedParentLabelMap.set(parentValue, parentLabel);
+          console.log("🏷️ Stored promotion context:", {
+            parentValue,
+            childLabel,
+            context,
+            parentLabel,
+          });
+        }
+
         // When an item is selected, clear the search and show all unselected options
         if (searchInputElement) {
           searchInputElement.value = "";
+          lastQuery = "";
         }
 
         // Only reset to static choices if we're in "options" mode
@@ -1469,6 +1551,7 @@
         // Always add custom search handling to filter out selected values
         searchInputElement.addEventListener("input", () => {
           const raw = searchInputElement!.value || "";
+          lastQuery = raw;
           if (debounceTimer) clearTimeout(debounceTimer);
           debounceTimer = setTimeout(async () => {
             const q = raw.trim();
@@ -1476,6 +1559,7 @@
               query: q,
               queryLength: q.length,
               minLength,
+              lastQuery,
               currentMode,
             });
 

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -110,7 +110,7 @@
 
     // Dynamic message builders (optional)
     tApiChildInSelectedParent = (child: string, parent: string) =>
-      `${child} result found is in ${parent} which is already selected`,
+      `${child} is in ${parent}, which is already selected`,
     tApiChildCoveredBySelectedChild = (
       child: string,
       parent: string,
@@ -121,9 +121,16 @@
       parent: string,
       children: string[],
     ) =>
-      `${parent} result found contains ${children.join(", ")} which ${
+      `${parent} contains ${children.join(", ")}, which ${
         children.length > 1 ? "are" : "is"
       } already selected`,
+
+    // Partial postcode promotion message (when promoteApiChildToParent is enabled)
+    tPartialPostcodeInSelectedParent = (
+      partialPostcode: string,
+      parent: string,
+    ) =>
+      `Postcodes beginning ${partialPostcode}... are in ${parent}, which is already selected`,
 
     // Behavioural tweaks
     resetApiSuggestionsAfterSelection = false,
@@ -194,6 +201,10 @@
     tStaticParentContainsSelectedChildren?: (
       parent: string,
       children: string[],
+    ) => string;
+    tPartialPostcodeInSelectedParent?: (
+      partialPostcode: string,
+      parent: string,
     ) => string;
 
     // Behavioural tweaks
@@ -1801,6 +1812,31 @@
                                 ),
                               },
                             );
+                          } else if (
+                            !isFullPostcode &&
+                            promoteApiChildToParent &&
+                            mappings.length > 0
+                          ) {
+                            // For partial postcodes with promotion enabled, show specific partial message
+                            const first = parentsSelected[0];
+                            const parentLabel =
+                              first.parent.label ?? String(first.parent.value);
+                            choicesInstance.config.noChoicesText =
+                              tPartialPostcodeInSelectedParent(
+                                q,
+                                parentLabel,
+                              );
+                            usedResolverMessage = true;
+                            console.log(
+                              "ℹ️ Partial postcode in selected parent (promotion mode)",
+                              {
+                                partialQuery: q,
+                                parentLabel,
+                                parents: parentsSelected.map(
+                                  (p) => p.parent.value,
+                                ),
+                              },
+                            );
                           }
                         }
                       }
@@ -2206,11 +2242,7 @@
                       console.warn("⚠️ staticChildrenResolver failed:", err);
                     }
                     if (!usedDynamic) {
-                      const hasStaticResolver =
-                        typeof staticChildrenResolver === "function";
-                      choicesInstance.config.noChoicesText = hasStaticResolver
-                        ? "All matching areas already covered by selected postcodes"
-                        : "All matching options are already selected";
+                      choicesInstance.config.noChoicesText = "All results are already selected";
                     }
                     console.log(
                       "ℹ️ Found static matches but all are already selected",

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -2275,7 +2275,10 @@
                   // Don't set noChoicesText when we have choices - let Choices.js handle it
 
                   // Apply searchResultLimit to the filtered choices
-                  const limitedChoices = filteredStaticChoicesByParent.slice(0, searchResultLimit);
+                  const limitedChoices = filteredStaticChoicesByParent.slice(
+                    0,
+                    searchResultLimit,
+                  );
 
                   // Ensure group text is applied to filtered choices
                   const choicesWithGroupText = ensureGroupTextApplied(

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -102,6 +102,32 @@
       "#0b0c0c", // Black
     ], // Complete GOV.UK Design System palette (19 colors)
 
+    // Cross-selection relationship resolvers (optional)
+    // If provided, they enable dynamic messages when results map to already-selected parents/children
+    apiParentResolver = undefined,
+    staticChildrenResolver = undefined,
+    selectedChildParentResolver = undefined,
+
+    // Dynamic message builders (optional)
+    tApiChildInSelectedParent = (child: string, parent: string) =>
+      `${child} result found is in ${parent} which is already selected`,
+    tApiChildCoveredBySelectedChild = (
+      child: string,
+      parent: string,
+      selectedChild: string,
+    ) =>
+      `${child} is in ${parent}, which is already covered by the selected postcode ${selectedChild}`,
+    tStaticParentContainsSelectedChildren = (
+      parent: string,
+      children: string[],
+    ) =>
+      `${parent} result found contains ${children.join(", ")} which ${
+        children.length > 1 ? "are" : "is"
+      } already selected`,
+
+    // Behavioural tweaks
+    resetApiSuggestionsAfterSelection = false,
+
     ...attributes
   }: {
     id: string;
@@ -140,6 +166,35 @@
     enableSelectedItemCircles?: boolean;
     selectedItemCircleColor?: string;
     selectedItemCircleColorPalette?: string[];
+
+    // Cross-selection relationship resolvers (optional)
+    apiParentResolver?:
+      | undefined
+      | ((entry: any) => { value: string | number; label?: string } | null);
+    staticChildrenResolver?:
+      | undefined
+      | ((
+          staticValue: string | number,
+          selectedValues: (string | number)[],
+        ) => (string | number)[] | Promise<(string | number)[]>);
+    selectedChildParentResolver?:
+      | undefined
+      | ((
+          selectedValue: string | number,
+        ) => { value: string | number; label?: string } | null);
+    tApiChildInSelectedParent?: (child: string, parent: string) => string;
+    tApiChildCoveredBySelectedChild?: (
+      child: string,
+      parent: string,
+      selectedChild: string,
+    ) => string;
+    tStaticParentContainsSelectedChildren?: (
+      parent: string,
+      children: string[],
+    ) => string;
+
+    // Behavioural tweaks
+    resetApiSuggestionsAfterSelection?: boolean;
 
     // Bindable state props for external synchronization
     // Use these to sync color state with other components
@@ -313,6 +368,8 @@
     value: string | number;
     label: string;
     disabled?: boolean;
+    labelPlain?: string;
+    raw?: any;
   };
   const staticChoices = $derived.by<ChoiceItem[]>(() => {
     /** @type {ChoiceItem[]} */
@@ -331,6 +388,7 @@
                <span class="gem-c-select-with-search__suggestion-group">${safeGroup}</span>
              </span>`
           : safeLabel,
+        labelPlain: String(it.text),
         disabled: it.disabled,
       });
     }
@@ -349,6 +407,7 @@
                  <span class="gem-c-select-with-search__suggestion-group">${safeGroup}</span>
                </span>`
             : safeLabel,
+          labelPlain: String(choice.text),
           disabled: g.disabled || choice.disabled,
         });
       }
@@ -550,6 +609,43 @@
     return label;
   }
 
+  // Resolve the parent LAD for a selected postcode value. Uses provided resolver first,
+  // then falls back to postcodes.io single lookup when available.
+  async function resolveParentOfSelectedChild(
+    selected: string | number,
+  ): Promise<{ value: string | number; label?: string } | null> {
+    try {
+      if (typeof selectedChildParentResolver === "function") {
+        const r = selectedChildParentResolver(selected);
+        if (r) return r;
+      }
+    } catch (e) {
+      console.warn("⚠️ selectedChildParentResolver error:", e);
+    }
+
+    // Best-effort fallback for postcodes.io
+    try {
+      if (
+        typeof selected === "string" &&
+        typeof source_url === "string" &&
+        /postcodes\.io\/postcodes\/?$/.test(source_url)
+      ) {
+        const pc = selected.replace(/\s+/g, "");
+        const url = `${source_url}${encodeURIComponent(pc)}`;
+        const res = await fetch(url);
+        const json = await res.json();
+        const result = json?.result;
+        const code = result?.codes?.lau2 || result?.codes?.lad;
+        const label = result?.admin_district ?? undefined;
+        if (code) return { value: code, label };
+      }
+    } catch (e) {
+      console.warn("⚠️ Fallback parent resolution failed:", e);
+    }
+
+    return null;
+  }
+
   async function fetchApiChoices(query: string): Promise<ChoiceItem[]> {
     const url = buildApiUrl(query);
     if (!url) return [];
@@ -574,6 +670,8 @@
                <span class="gem-c-select-with-search__suggestion-group">${safeGroup}</span>
              </span>`
           : safeLabel,
+        labelPlain: label,
+        raw: entry,
       };
     });
 
@@ -1306,6 +1404,19 @@
               }, 0);
             }
           }, 0);
+        } else if (currentMode === "api" && resetApiSuggestionsAfterSelection) {
+          // Clear API suggestions after a selection and close dropdown
+          setTimeout(() => {
+            try {
+              choicesInstance.clearChoices();
+              choicesInstance.setChoices([], "value", "label", true);
+              // Force dropdown to close
+              choicesInstance.hideDropdown(true);
+              console.log("🔄 Cleared API suggestions after selection");
+            } catch (e) {
+              console.warn("⚠️ Failed to clear API suggestions:", e);
+            }
+          }, 0);
         } else {
           console.log(
             "🔄 Staying in current mode after selection:",
@@ -1455,42 +1566,254 @@
                   })),
                 });
 
-                if (filteredApiChoices.length === 0) {
+                // Determine if the query is a full postcode (used to gate messages)
+                const isFullPostcode = looksLikePostcode(q);
+
+                // If resolver is provided, optionally hide results that all map to selected parents
+                try {
+                  if (
+                    isFullPostcode &&
+                    typeof apiParentResolver === "function" &&
+                    filteredApiChoices.length > 0
+                  ) {
+                    const covered = filteredApiChoices
+                      .map((c) => ({
+                        childValue: String(c.value),
+                        childLabel: c.labelPlain ?? String(c.value),
+                        parent: apiParentResolver(c.raw),
+                      }))
+                      .filter(
+                        (m) => m.parent && m.parent.value != null,
+                      ) as Array<{
+                      childValue: string;
+                      childLabel: string;
+                      parent: { value: string | number; label?: string };
+                    }>;
+
+                    const allCovered =
+                      covered.length === filteredApiChoices.length &&
+                      covered.every((m) =>
+                        selectedValues.includes(String(m.parent.value)),
+                      );
+
+                    if (allCovered) {
+                      const first = covered[0];
+                      const parentLabel =
+                        first.parent.label ?? String(first.parent.value);
+                      choicesInstance.config.noChoicesText =
+                        tApiChildInSelectedParent(
+                          first.childLabel,
+                          parentLabel,
+                        );
+                      choicesInstance.setChoices([], "value", "label", true);
+                      return;
+                    }
+                  }
+                } catch (err) {
+                  console.warn(
+                    "⚠️ apiParentResolver coverage check failed:",
+                    err,
+                  );
+                }
+
+                // Full vs partial postcode handling
+
+                // If full postcode exactly and it maps to a selected parent, show message
+                if (isFullPostcode && typeof apiParentResolver === "function") {
+                  const normalize = (s: string) =>
+                    String(s).replace(/\s+/g, "").toUpperCase();
+                  const exact = apiChoices.find(
+                    (c) =>
+                      normalize(String(c.value)) === normalize(q) ||
+                      normalize(c.labelPlain ?? "") === normalize(q),
+                  );
+                  if (exact) {
+                    try {
+                      const parent = apiParentResolver((exact as any).raw);
+                      if (parent && parent.value != null) {
+                        const parentLabel =
+                          parent.label ?? String(parent.value);
+                        if (selectedValues.includes(String(parent.value))) {
+                          choicesInstance.config.noChoicesText =
+                            tApiChildInSelectedParent(
+                              String(exact.labelPlain ?? exact.value),
+                              parentLabel,
+                            );
+                          choicesInstance.setChoices(
+                            [],
+                            "value",
+                            "label",
+                            true,
+                          );
+                          return;
+                        }
+                        {
+                          const coverParents = await Promise.all(
+                            (selectedValues || []).map((sv) =>
+                              resolveParentOfSelectedChild(sv),
+                            ),
+                          );
+                          const idx = coverParents.findIndex(
+                            (rel) =>
+                              rel && String(rel.value) === String(parent.value),
+                          );
+                          const coveringChild =
+                            idx >= 0 ? selectedValues[idx] : null;
+                          if (coveringChild) {
+                            choicesInstance.config.noChoicesText =
+                              tApiChildCoveredBySelectedChild(
+                                String(exact.labelPlain ?? exact.value),
+                                parentLabel,
+                                String(coveringChild),
+                              );
+                            choicesInstance.setChoices(
+                              [],
+                              "value",
+                              "label",
+                              true,
+                            );
+                            return;
+                          }
+                        }
+                      }
+                    } catch {}
+                  }
+                }
+
+                // For partial postcodes, hide suggestions that belong to already-selected parents
+                let filteredByParent = filteredApiChoices;
+                if (
+                  !isFullPostcode &&
+                  typeof apiParentResolver === "function"
+                ) {
+                  // Build a set of parent LAD codes covered by any currently selected postcode(s)
+                  let selectedParentSet = new Set<string>();
+                  try {
+                    const rels = await Promise.all(
+                      (selectedValues || []).map((sv) =>
+                        resolveParentOfSelectedChild(sv),
+                      ),
+                    );
+                    for (const r of rels)
+                      if (r && r.value != null)
+                        selectedParentSet.add(String(r.value));
+                  } catch (e) {
+                    console.warn(
+                      "⚠️ Failed to build selected parents set for partial filtering:",
+                      e,
+                    );
+                  }
+
+                  filteredByParent = filteredApiChoices.filter((c) => {
+                    try {
+                      const parent = apiParentResolver((c as any).raw);
+                      return !(
+                        parent &&
+                        parent.value != null &&
+                        (selectedValues.includes(String(parent.value)) ||
+                          selectedParentSet.has(String(parent.value)))
+                      );
+                    } catch {
+                      return true;
+                    }
+                  });
+                }
+
+                if (filteredByParent.length === 0) {
                   // No new results from API. Determine the correct message.
                   if (apiChoices.length === 0) {
                     // API returned no results for the query.
                     choicesInstance.config.noChoicesText = "No results found";
                     console.log("❌ API returned no results");
                   } else {
-                    // API returned results, but they are all already selected.
-                    // Double-check this by looking at the actual values
-                    const allResultsSelected = apiChoices.every((choice) =>
-                      selectedValues.includes(String(choice.value)),
-                    );
+                    // API returned results, but they are all already selected or map to selected parents.
+                    // Prefer resolver-based message if available.
+                    let usedResolverMessage = false;
+                    try {
+                      if (typeof apiParentResolver === "function") {
+                        // Map each API choice to its parent and check if parent is selected
+                        const mappings = apiChoices
+                          .map((c) => ({
+                            childValue: String(c.value),
+                            childLabel: c.labelPlain ?? String(c.value),
+                            parent: apiParentResolver(c.raw),
+                          }))
+                          .filter(
+                            (m) => !!m.parent && m.parent.value != null,
+                          ) as Array<{
+                          childValue: string;
+                          childLabel: string;
+                          parent: { value: string | number; label?: string };
+                        }>;
 
-                    if (allResultsSelected) {
-                      choicesInstance.config.noChoicesText =
-                        "All results are already selected";
-                      console.log(
-                        "ℹ️ API returned results but all are already selected",
-                        {
-                          apiResults: apiChoices.map((c) => c.value),
-                          selectedValues,
-                          allResultsSelected,
-                        },
+                        const parentsSelected = mappings.filter((m) =>
+                          selectedValues.includes(String(m.parent.value)),
+                        );
+
+                        if (
+                          mappings.length > 0 &&
+                          parentsSelected.length === mappings.length
+                        ) {
+                          // Only show specific message if single candidate or full postcode
+                          if (isFullPostcode || apiChoices.length === 1) {
+                            const first = parentsSelected[0];
+                            const parentLabel =
+                              first.parent.label ?? String(first.parent.value);
+                            const childLabel = first.childLabel;
+                            choicesInstance.config.noChoicesText =
+                              tApiChildInSelectedParent(
+                                childLabel,
+                                parentLabel,
+                              );
+                            usedResolverMessage = true;
+                            console.log(
+                              "ℹ️ API choices map to already-selected parents (specific)",
+                              {
+                                parentLabel,
+                                childLabel,
+                                parents: parentsSelected.map(
+                                  (p) => p.parent.value,
+                                ),
+                              },
+                            );
+                          }
+                        }
+                      }
+                    } catch (err) {
+                      console.warn("⚠️ apiParentResolver failed:", err);
+                    }
+
+                    if (!usedResolverMessage) {
+                      // Fallback to previous messages
+                      const allResultsSelected = apiChoices.every((choice) =>
+                        selectedValues.includes(String(choice.value)),
                       );
-                    } else {
-                      // This shouldn't happen, but fallback to a generic message
-                      choicesInstance.config.noChoicesText =
-                        "No new results available";
-                      console.log(
-                        "⚠️ Unexpected: API returned results but filtering logic failed",
-                        {
-                          apiResults: apiChoices.map((c) => c.value),
-                          selectedValues,
-                          filteredCount: filteredApiChoices.length,
-                        },
-                      );
+
+                      if (allResultsSelected) {
+                        choicesInstance.config.noChoicesText =
+                          "All results are already selected";
+                        console.log(
+                          "ℹ️ API returned results but all are already selected",
+                          {
+                            apiResults: apiChoices.map((c) => c.value),
+                            selectedValues,
+                            allResultsSelected,
+                          },
+                        );
+                      } else {
+                        // This shouldn't happen, but fallback to a generic message
+                        choicesInstance.config.noChoicesText = isFullPostcode
+                          ? "No new results available"
+                          : "All postcode suggestions cover an area that is already covered by a currently selected postcode or area";
+                        console.log(
+                          "⚠️ Unexpected: API returned results but filtering logic failed",
+                          {
+                            apiResults: apiChoices.map((c) => c.value),
+                            selectedValues,
+                            filteredCount: filteredByParent.length,
+                          },
+                        );
+                      }
                     }
                   }
                   // Clear the list and show the message.
@@ -1511,8 +1834,45 @@
                   );
 
                   if (allResultsSimilarToSelected) {
-                    choicesInstance.config.noChoicesText =
-                      "All results are already selected";
+                    // Try resolver-based message first, otherwise default
+                    let setMsg = false;
+                    try {
+                      if (typeof apiParentResolver === "function") {
+                        const mappings = apiChoices
+                          .map((c) => ({
+                            childValue: String(c.value),
+                            childLabel: c.labelPlain ?? String(c.value),
+                            parent: apiParentResolver(c.raw),
+                          }))
+                          .filter(
+                            (m) => !!m.parent && m.parent.value != null,
+                          ) as Array<{
+                          childValue: string;
+                          childLabel: string;
+                          parent: { value: string | number; label?: string };
+                        }>;
+
+                        const match = mappings.find((m) =>
+                          selectedValues.includes(String(m.parent.value)),
+                        );
+                        if (match) {
+                          const parentLabel =
+                            match.parent.label ?? String(match.parent.value);
+                          choicesInstance.config.noChoicesText =
+                            tApiChildInSelectedParent(
+                              match.childLabel,
+                              parentLabel,
+                            );
+                          setMsg = true;
+                        }
+                      }
+                    } catch (err) {
+                      console.warn("⚠️ apiParentResolver failed:", err);
+                    }
+                    if (!setMsg) {
+                      choicesInstance.config.noChoicesText =
+                        "All results are already selected";
+                    }
                     console.log(
                       "🎯 Query matches selected items, showing 'all selected' message",
                       {
@@ -1530,7 +1890,7 @@
                     // Ensure group text is applied to filtered API choices
                     const filteredApiChoicesWithGroupText =
                       ensureGroupTextApplied(
-                        filteredApiChoices.map((c) => ({
+                        filteredByParent.map((c) => ({
                           value: String(c.value),
                           label: c.label,
                         })),
@@ -1544,7 +1904,7 @@
                     );
                     console.log(
                       "✅ Set filtered API choices (some similar to selected):",
-                      filteredApiChoices.length,
+                      filteredByParent.length,
                     );
                   }
                 } else {
@@ -1553,7 +1913,7 @@
 
                   // Ensure group text is applied to API choices
                   const apiChoicesWithGroupText = ensureGroupTextApplied(
-                    filteredApiChoices.map((c) => ({
+                    filteredByParent.map((c) => ({
                       value: String(c.value),
                       label: c.label,
                     })),
@@ -1571,7 +1931,7 @@
 
                   console.log(
                     "✅ Set new API choices:",
-                    filteredApiChoices.length,
+                    filteredByParent.length,
                   );
                 }
               } catch (e) {
@@ -1644,18 +2004,129 @@
                     matchingChoices.length - filteredStaticChoices.length,
                 });
 
+                // Further exclude parents that already contain selected postcodes
+                let filteredStaticChoicesByParent = filteredStaticChoices;
+                try {
+                  if (
+                    typeof staticChildrenResolver === "function" &&
+                    filteredStaticChoices.length > 0
+                  ) {
+                    const checks = await Promise.all(
+                      filteredStaticChoices.map(async (ch) => {
+                        try {
+                          const children = await Promise.resolve(
+                            staticChildrenResolver(ch.value, selectedValues),
+                          );
+                          return {
+                            choice: ch,
+                            hasChildren: (children || []).length > 0,
+                          };
+                        } catch (e) {
+                          return { choice: ch, hasChildren: false };
+                        }
+                      }),
+                    );
+                    filteredStaticChoicesByParent = checks
+                      .filter((x) => !x.hasChildren)
+                      .map((x) => x.choice);
+                    console.log("🔍 Static choices after parent exclusion:", {
+                      before: filteredStaticChoices.length,
+                      after: filteredStaticChoicesByParent.length,
+                    });
+                  }
+                } catch (err) {
+                  console.warn(
+                    "⚠️ staticChildrenResolver exclusion failed:",
+                    err,
+                  );
+                }
+
+                // Before rendering, if resolver says this typed parent contains selected children,
+                // show a dynamic message instead of suggestions — but only when the query uniquely
+                // identifies a single parent (i.e. exactly one matching choice)
+                try {
+                  if (
+                    typeof staticChildrenResolver === "function" &&
+                    matchingChoices.length === 1
+                  ) {
+                    const parentChoice = matchingChoices[0];
+                    const children = await Promise.resolve(
+                      staticChildrenResolver(
+                        parentChoice.value,
+                        selectedValues,
+                      ),
+                    );
+                    const childStrings = (children || []).map((c) => String(c));
+                    if (childStrings.length > 0) {
+                      const parentLabelCandidate =
+                        parentChoice.labelPlain ?? parentChoice.label;
+                      choicesInstance.config.noChoicesText =
+                        tStaticParentContainsSelectedChildren(
+                          String(parentLabelCandidate),
+                          childStrings,
+                        );
+                      choicesInstance.clearChoices();
+                      choicesInstance.setChoices([], "value", "label", true);
+                      return;
+                    }
+                  }
+                } catch (err) {
+                  console.warn(
+                    "⚠️ staticChildrenResolver dynamic message failed:",
+                    err,
+                  );
+                }
+
                 choicesInstance.clearChoices();
 
-                if (filteredStaticChoices.length === 0) {
+                if (filteredStaticChoicesByParent.length === 0) {
                   // No choices to show - distinguish between no matches vs all selected
                   if (matchingChoices.length === 0) {
                     // No search matches at all
                     choicesInstance.config.noChoicesText = "No results found";
                     console.log("❌ No static choices match search term");
                   } else {
-                    // Found matches but all are already selected
-                    choicesInstance.config.noChoicesText =
-                      "All matching options are already selected";
+                    // Found matches but all are already selected.
+                    // Try child mapping detection: selected children that belong to a typed parent
+                    let usedDynamic = false;
+                    try {
+                      if (
+                        typeof staticChildrenResolver === "function" &&
+                        matchingChoices.length === 1
+                      ) {
+                        // Determine which selected values belong to the typed parent (only when unique)
+                        const parentLabelCandidate =
+                          matchingChoices[0]?.labelPlain ??
+                          matchingChoices[0]?.label ??
+                          "";
+                        const children = await Promise.resolve(
+                          staticChildrenResolver(
+                            matchingChoices[0]?.value,
+                            selectedValues,
+                          ),
+                        );
+                        const childrenStrings = (children || []).map((c) =>
+                          String(c),
+                        );
+                        if (childrenStrings.length > 0) {
+                          choicesInstance.config.noChoicesText =
+                            tStaticParentContainsSelectedChildren(
+                              String(parentLabelCandidate),
+                              childrenStrings,
+                            );
+                          usedDynamic = true;
+                        }
+                      }
+                    } catch (err) {
+                      console.warn("⚠️ staticChildrenResolver failed:", err);
+                    }
+                    if (!usedDynamic) {
+                      const hasStaticResolver =
+                        typeof staticChildrenResolver === "function";
+                      choicesInstance.config.noChoicesText = hasStaticResolver
+                        ? "All matching areas already covered by selected postcodes"
+                        : "All matching options are already selected";
+                    }
                     console.log(
                       "ℹ️ Found static matches but all are already selected",
                     );
@@ -1668,7 +2139,7 @@
 
                   // Ensure group text is applied to filtered choices
                   const choicesWithGroupText = ensureGroupTextApplied(
-                    filteredStaticChoices.map((c) => ({
+                    filteredStaticChoicesByParent.map((c) => ({
                       value: String(c.value),
                       label: c.label,
                       disabled: c.disabled,
@@ -1687,7 +2158,7 @@
 
                   console.log(
                     "✅ Set filtered static choices:",
-                    filteredStaticChoices.length,
+                    filteredStaticChoicesByParent.length,
                   );
                 }
               }

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -437,9 +437,14 @@
     if (fullWidth) {
       // Remove existing width classes and add w-full
       const withoutWidthClasses = formGroupClasses
-        .split(' ')
-        .filter(cls => !cls.startsWith('w-') && !cls.startsWith('max-w-') && !cls.startsWith('min-w-'))
-        .join(' ');
+        .split(" ")
+        .filter(
+          (cls) =>
+            !cls.startsWith("w-") &&
+            !cls.startsWith("max-w-") &&
+            !cls.startsWith("min-w-"),
+        )
+        .join(" ");
       return `${withoutWidthClasses} w-full`.trim();
     }
     return formGroupClasses;

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -38,7 +38,7 @@
     searchPlaceholder = "Search in list",
     allowHTML = true,
     shouldSort = false,
-    searchResultLimit = 100,
+    searchResultLimit = 6,
     removeItemButton = true, // Will default to multiple if not specified
 
     // Styling and layout - pass through to Select component
@@ -2274,9 +2274,12 @@
                   // Have choices to show
                   // Don't set noChoicesText when we have choices - let Choices.js handle it
 
+                  // Apply searchResultLimit to the filtered choices
+                  const limitedChoices = filteredStaticChoicesByParent.slice(0, searchResultLimit);
+
                   // Ensure group text is applied to filtered choices
                   const choicesWithGroupText = ensureGroupTextApplied(
-                    filteredStaticChoicesByParent.map((c) => ({
+                    limitedChoices.map((c) => ({
                       value: String(c.value),
                       label: c.label,
                       disabled: c.disabled,
@@ -2295,7 +2298,7 @@
 
                   console.log(
                     "✅ Set filtered static choices:",
-                    filteredStaticChoicesByParent.length,
+                    limitedChoices.length,
                   );
                 }
               }

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -737,6 +737,7 @@
     if (groups && groups.length > 0) {
       console.log("📋 Restoring grouped options structure");
 
+      // For grouped options, revert to destroy/recreate approach (only reliable method)
       // Clear current choices
       choicesInstance.clearChoices();
 
@@ -752,7 +753,7 @@
           const placeholderOption = document.createElement("option");
           placeholderOption.value = "";
           placeholderOption.textContent = computedPlaceholderText;
-          placeholderOption.selected = true;
+          placeholderOption.selected = selectedValues.length === 0;
           selectElement.appendChild(placeholderOption);
         }
 
@@ -765,8 +766,7 @@
             const option = document.createElement("option");
             option.value = String(choice.value);
             option.textContent = String(choice.text);
-            option.disabled =
-              choice.disabled || false || group.disabled || false;
+            option.disabled = choice.disabled || false || group.disabled || false;
 
             // Check if this option is currently selected
             if (selectedValues.includes(String(choice.value))) {
@@ -781,117 +781,39 @@
           }
         });
 
+        // Store the existing template callback before destroying
+        const existingTemplateCallback = choicesInstance.config.callbackOnCreateTemplates;
+
         // Reinitialize Choices.js with the restored structure
         choicesInstance.destroy();
         if (selectElement) {
           choicesInstance = new Choices(selectElement, {
             allowHTML,
             searchPlaceholderValue: searchPlaceholder,
-            shouldSort: false, // Force false to preserve placeholder position
-            placeholder: true, // Ensure placeholder option is treated as placeholder
+            shouldSort: false,
+            placeholder: true,
             itemSelectText: "",
             searchResultLimit,
             removeItemButton: computedRemoveItemButton,
-            labelId:
-              id +
-              "-label " +
-              (selectElement.getAttribute("aria-describedby") || ""),
+            labelId: id + "-label " + (selectElement.getAttribute("aria-describedby") || ""),
             searchFloor: minLength,
-            // Don't set searchChoices here - let applyMode handle it
-            // Don't set noChoicesText here - let the search logic handle it
             duplicateItemsAllowed: false,
             fuseOptions: {
               ignoreLocation: true,
               threshold: 0,
             },
-            // Add the custom template callback to preserve colored circles
-            callbackOnCreateTemplates: function (strToEl: any) {
-              // public class names exposed by Choices
-              const cn = this.config.classNames;
-              const isMulti = this.passedElement?.element?.multiple === true;
-
-              // small escape for when allowHTML=false
-              const esc = (s: string) =>
-                String(s)
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;");
-
-              // try to keep any existing templates if your build exposes them
-              const base = (this as any)._templates ?? {};
-
-              return {
-                ...base,
-
-                // Custom item template for chips (selected items), not dropdown choices
-                item: (_classNames: any, data: any) => {
-                  const classes = [
-                    cn.item,
-                    data.highlighted ? cn.highlightedState : cn.itemSelectable,
-                    data.placeholder ? cn.placeholder : "",
-                  ]
-                    .filter(Boolean)
-                    .join(" ");
-
-                  // ✅ Decide if this chip should be deletable
-                  const showRemove =
-                    isMulti && this.config.removeItemButton && !data.disabled;
-
-                  // Circle
-                  let circle = "";
-                  if (enableSelectedItemCircles && isMulti && data.active) {
-                    const color = colorForValue(data.value); // ✅ value-only, stable
-                    circle = `<span class="choices__item-circle" style="background:${color}"></span>`;
-                  }
-
-                  // Label
-                  const labelHtml = allowHTML ? data.label : esc(data.label);
-
-                  // Remove button (same markup Choices normally generates)
-                  const removeBtn = showRemove
-                    ? `<button type="button"
-                               class="${cn.button}"
-                               data-button
-                               aria-label="Remove ${esc(String(data.value))}"></button>`
-                    : "";
-
-                  return strToEl(
-                    `<div class="${classes}"
-                          data-item
-                          data-id="${data.id}"
-                          data-value="${String(data.value)}"
-                          ${showRemove ? "data-deletable" : ""}
-                          ${data.active ? 'aria-selected="true"' : ""}
-                          ${data.disabled ? 'aria-disabled="true"' : ""}>
-                        ${circle}${labelHtml}${removeBtn}
-                     </div>`,
-                  );
-                },
-              };
-            },
+            // Reuse the existing template callback (no duplication)
+            callbackOnCreateTemplates: existingTemplateCallback,
             ...choicesOptions,
           });
 
           // Store reference on the element for external access
           (selectElement as any).choices = choicesInstance;
-
-          // For grouped options, don't re-apply mode as it would overwrite the grouped structure
-          // The grouped structure is already restored above
-          console.log(
-            "✅ Grouped structure restored, skipping mode re-application",
-          );
-
-          // Restore focus to the main Choices container after reinitialization
-          setTimeout(() => {
-            if (choicesInstance?.containerOuter?.element) {
-              choicesInstance.containerOuter.element.focus();
-              console.log("🎯 Focus restored to Choices container");
-            }
-          }, 0);
+          
+          console.log("✅ Grouped structure restored with reinit");
         }
-
-        console.log("✅ Restored grouped options structure");
       }
+      console.log("✅ Restored grouped options structure");
     } else {
       // For non-grouped options, use the existing logic
       console.log("📋 Restoring flat options structure");
@@ -972,7 +894,7 @@
     // Clear current list but keep the instance intact (preserves focus)
     choicesInstance.clearChoices();
 
-    // Build grouped payload excluding currently selected values
+    // Build grouped payload EXCLUDING selected values (same as original approach)
     const groupedPayload = groups.map((grp: any) => ({
       label: grp.label,
       disabled: !!grp.disabled,
@@ -1000,10 +922,9 @@
 
     // Pass grouped data to Choices so it renders headings properly
     choicesInstance.setChoices(list, "value", "label", true);
+    
     console.log("✅ Grouped options restored in-place");
-  }
-
-  // Initialize Choices.js
+  }  // Initialize Choices.js
   onMount(async () => {
     console.log("🔧 MultiSelectSearchAutocomplete: onMount started", {
       id,

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -40,6 +40,7 @@
     shouldSort = false,
     searchResultLimit = 6,
     removeItemButton = true, // Will default to multiple if not specified
+    showSearchIcon = true,
 
     // Styling and layout - pass through to Select component
     formGroupClasses = "",
@@ -161,6 +162,7 @@
     shouldSort?: boolean;
     searchResultLimit?: number;
     removeItemButton?: boolean;
+    showSearchIcon?: boolean;
     formGroupClasses?: string;
     fullWidth?: boolean;
     describedBy?: string;
@@ -2593,7 +2595,7 @@
     {describedBy}
     {disabled}
     bind:selectElement
-    renderRight={rightIcon}
+    renderRight={showSearchIcon ? rightIcon : undefined}
     {...attributes}
   />
 </div>

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -640,31 +640,6 @@
     // Force refresh to show the message
   }
 
-  // Default selection logic between API and static options
-  function selectSource(query: string): "api" | "options" {
-    if (typeof sourceSelector === "function") {
-      try {
-        return sourceSelector(query, staticPlainOptions);
-      } catch {
-        // fall through to default
-      }
-    }
-
-    // Check if we have static options (items or groups with choices)
-    const hasStaticOptions =
-      (items && items.length > 0) ||
-      (groups && groups.some((g) => g.choices && g.choices.length > 0));
-
-    // If we have static options, use them; otherwise default to API if configured
-    if (hasStaticOptions) {
-      return "options";
-    } else if (source_url && source_key && query.trim().length >= minLength) {
-      return "api";
-    } else {
-      return "options"; // fallback to options even if empty
-    }
-  }
-
   // Build URL for API requests. Replaces {query} placeholder or appends ?q=
   function buildApiUrl(query: string): string {
     if (!source_url) return "";
@@ -689,12 +664,6 @@
     } catch {
       return String(o);
     }
-  }
-
-  function toValue(o: any, label: string): string | number {
-    if (o && typeof o === "object" && "value" in o && o.value != null)
-      return o.value as string | number;
-    return label;
   }
 
   async function fetchApiChoices(query: string): Promise<ChoiceItem[]> {
@@ -1194,11 +1163,8 @@
         ? baseNoChoicesText
         : tTooShort(minLength);
 
-      const hasApiConfig = source_url && source_key;
-
       console.log("📊 Initial configuration:", {
         hasStaticOptions,
-        hasApiConfig,
         initialNoChoicesText,
         staticChoices: staticChoices.length,
         enhancedItems: enhancedItems.length,
@@ -1449,7 +1415,6 @@
         // When an item is selected, clear the search and show all unselected options
         if (searchInputElement) {
           searchInputElement.value = "";
-          lastQuery = "";
         }
 
         // Only reset to static choices if we're in "options" mode
@@ -1530,7 +1495,6 @@
         // Always add custom search handling to filter out selected values
         searchInputElement.addEventListener("input", () => {
           const raw = searchInputElement!.value || "";
-          lastQuery = raw;
           if (debounceTimer) clearTimeout(debounceTimer);
           debounceTimer = setTimeout(async () => {
             const q = raw.trim();

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -1446,27 +1446,6 @@
       selectElement.addEventListener("choice", (ev: any) => {
         console.log("🎯 Choice selected, resetting search");
 
-        // Check if this was a promoted choice and store context
-        const choice = ev?.detail?.choice;
-        if (
-          choice?.customProperties?.isPromoted &&
-          choice.customProperties.parentValue &&
-          choice.customProperties.childLabel
-        ) {
-          const parentValue = choice.customProperties.parentValue;
-          const childLabel = choice.customProperties.childLabel;
-          const parentLabel = choice.customProperties.parentLabel || undefined;
-          const context = `(containing ${childLabel})`;
-          promotedItemContext.set(parentValue, context);
-          if (parentLabel) promotedParentLabelMap.set(parentValue, parentLabel);
-          console.log("🏷️ Stored promotion context:", {
-            parentValue,
-            childLabel,
-            context,
-            parentLabel,
-          });
-        }
-
         // When an item is selected, clear the search and show all unselected options
         if (searchInputElement) {
           searchInputElement.value = "";

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -766,7 +766,8 @@
             const option = document.createElement("option");
             option.value = String(choice.value);
             option.textContent = String(choice.text);
-            option.disabled = choice.disabled || false || group.disabled || false;
+            option.disabled =
+              choice.disabled || false || group.disabled || false;
 
             // Check if this option is currently selected
             if (selectedValues.includes(String(choice.value))) {
@@ -782,7 +783,8 @@
         });
 
         // Store the existing template callback before destroying
-        const existingTemplateCallback = choicesInstance.config.callbackOnCreateTemplates;
+        const existingTemplateCallback =
+          choicesInstance.config.callbackOnCreateTemplates;
 
         // Reinitialize Choices.js with the restored structure
         choicesInstance.destroy();
@@ -795,7 +797,10 @@
             itemSelectText: "",
             searchResultLimit,
             removeItemButton: computedRemoveItemButton,
-            labelId: id + "-label " + (selectElement.getAttribute("aria-describedby") || ""),
+            labelId:
+              id +
+              "-label " +
+              (selectElement.getAttribute("aria-describedby") || ""),
             searchFloor: minLength,
             duplicateItemsAllowed: false,
             fuseOptions: {
@@ -809,7 +814,7 @@
 
           // Store reference on the element for external access
           (selectElement as any).choices = choicesInstance;
-          
+
           console.log("✅ Grouped structure restored with reinit");
         }
       }
@@ -922,9 +927,9 @@
 
     // Pass grouped data to Choices so it renders headings properly
     choicesInstance.setChoices(list, "value", "label", true);
-    
+
     console.log("✅ Grouped options restored in-place");
-  }  // Initialize Choices.js
+  } // Initialize Choices.js
   onMount(async () => {
     console.log("🔧 MultiSelectSearchAutocomplete: onMount started", {
       id,

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -220,9 +220,7 @@
   let choicesInstance: any;
   let searchInputElement: HTMLInputElement | null = null;
   let debounceTimer: any = null;
-  let lastQuery = "";
   const baseNoChoicesText = "No choices to choose from";
-  let isProcessingPromotion = false;
 
   // Track context for promoted items (postcode -> LAD promotions)
   const promotedItemContext = $state(new Map<string, string>());
@@ -614,30 +612,7 @@
     // Force refresh to show the message
   }
 
-  // Default selection logic between API and static options
-  function selectSource(query: string): "api" | "options" {
-    if (typeof sourceSelector === "function") {
-      try {
-        return sourceSelector(query, staticPlainOptions);
-      } catch {
-        // fall through to default
-      }
-    }
-
-    // Check if we have static options (items or groups with choices)
-    const hasStaticOptions =
-      (items && items.length > 0) ||
-      (groups && groups.some((g) => g.choices && g.choices.length > 0));
-
-    // If we have static options, use them; otherwise default to API if configured
-    if (hasStaticOptions) {
-      return "options";
-    } else if (source_url && source_key && query.trim().length >= minLength) {
-      return "api";
-    } else {
-      return "options"; // fallback to options even if empty
-    }
-  }
+  // selectSource removed (decideMode handles mode selection)
 
   // Build URL for API requests. Replaces {query} placeholder or appends ?q=
   function buildApiUrl(query: string): string {
@@ -665,11 +640,7 @@
     }
   }
 
-  function toValue(o: any, label: string): string | number {
-    if (o && typeof o === "object" && "value" in o && o.value != null)
-      return o.value as string | number;
-    return label;
-  }
+  // toValue removed (no longer used)
 
   async function fetchApiChoices(query: string): Promise<ChoiceItem[]> {
     const url = buildApiUrl(query);
@@ -1173,11 +1144,8 @@
         ? baseNoChoicesText
         : tTooShort(minLength);
 
-      const hasApiConfig = source_url && source_key;
-
       console.log("📊 Initial configuration:", {
         hasStaticOptions,
-        hasApiConfig,
         initialNoChoicesText,
         staticChoices: staticChoices.length,
         enhancedItems: enhancedItems.length,
@@ -1421,7 +1389,6 @@
         // When an item is selected, clear the search and show all unselected options
         if (searchInputElement) {
           searchInputElement.value = "";
-          lastQuery = "";
         }
 
         // Only reset to static choices if we're in "options" mode
@@ -1502,7 +1469,6 @@
         // Always add custom search handling to filter out selected values
         searchInputElement.addEventListener("input", () => {
           const raw = searchInputElement!.value || "";
-          lastQuery = raw;
           if (debounceTimer) clearTimeout(debounceTimer);
           debounceTimer = setTimeout(async () => {
             const q = raw.trim();
@@ -1510,7 +1476,6 @@
               query: q,
               queryLength: q.length,
               minLength,
-              lastQuery,
               currentMode,
             });
 

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -226,6 +226,8 @@
 
   // Track context for promoted items (postcode -> LAD promotions)
   const promotedItemContext = $state(new Map<string, string>());
+  // Track parent labels for promoted items when not present in static options
+  const promotedParentLabelMap = $state(new Map<string, string>());
 
   // Dev inspect: track selection history without logging proxies
   let __lastSnapshot: string[] = [];
@@ -1425,12 +1427,15 @@
         ) {
           const parentValue = choice.customProperties.parentValue;
           const childLabel = choice.customProperties.childLabel;
+          const parentLabel = choice.customProperties.parentLabel || undefined;
           const context = `(containing ${childLabel})`;
           promotedItemContext.set(parentValue, context);
+          if (parentLabel) promotedParentLabelMap.set(parentValue, parentLabel);
           console.log("🏷️ Stored promotion context:", {
             parentValue,
             childLabel,
             context,
+            parentLabel,
           });
         }
 
@@ -2054,6 +2059,15 @@
                           const parent = apiParentResolver((c as any).raw);
                           if (parent && parent.value != null) {
                             const parentValue = String(parent.value);
+                            // Cache parent label so chips can render even if parent not in static items
+                            try {
+                              const parentLabelCache =
+                                parent.label || parentValue;
+                              promotedParentLabelMap.set(
+                                parentValue,
+                                parentLabelCache,
+                              );
+                            } catch {}
                             const childValue = String(c.value);
                             // Use composite value to ensure uniqueness while storing parent info
                             const compositeValue = `${parentValue}::${childValue}`;
@@ -2464,31 +2478,37 @@
           value.forEach((val) => {
             const key = String(val);
             if (promotedItemContext.has(key)) {
-              const staticChoice = staticChoices.find(
-                (c) => String(c.value) === key,
-              );
-              if (staticChoice) {
-                const context = promotedItemContext.get(key)!;
-                const newLabel = `<span class="choices__item-label">
-                   <span class="choices__item-main">${escapeHtml(staticChoice.labelPlain ?? "")}</span>
-                   <span class="gem-c-select-with-search__suggestion-group">${escapeHtml(context)}</span>
-                 </span>`;
-                mergedChoices.set(key, {
-                  ...staticChoice,
-                  label: newLabel,
-                  customProperties: {
-                    parentValue: key,
-                    parentLabel:
-                      staticChoice.labelPlain ?? String(staticChoice.value),
-                    childLabel: context.replace(/^\(containing |\)$/g, ""), // Extract just the postcode from "(containing TW5 0AA)"
-                  },
-                });
-                console.log("🛠️ Manually crafted choice for promoted item:", {
-                  key,
-                  newLabel,
-                  context,
-                });
-              }
+              const context = promotedItemContext.get(key)!;
+              const parentLabelFallback =
+                promotedParentLabelMap.get(key) || undefined;
+              const baseChoice =
+                staticChoices.find((c) => String(c.value) === key) ||
+                ({
+                  value: key,
+                  label: parentLabelFallback ?? String(key),
+                  labelPlain: parentLabelFallback ?? String(key),
+                } as any);
+
+              const newLabel = `<span class="choices__item-label">
+                 <span class="choices__item-main">${escapeHtml(baseChoice.labelPlain ?? "")}</span>
+                 <span class="gem-c-select-with-search__suggestion-group">${escapeHtml(context)}</span>
+               </span>`;
+              mergedChoices.set(key, {
+                ...baseChoice,
+                label: newLabel,
+                customProperties: {
+                  parentValue: key,
+                  parentLabel:
+                    baseChoice.labelPlain ?? String(baseChoice.value),
+                  childLabel: context.replace(/^\(containing |\)$/g, ""),
+                },
+              });
+              console.log("🛠️ Manually crafted choice for promoted item:", {
+                key,
+                newLabel,
+                context,
+                parentLabelFallback,
+              });
             }
           });
         }

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -127,6 +127,9 @@
 
     // Behavioural tweaks
     resetApiSuggestionsAfterSelection = false,
+    // Promote API child (e.g., postcode) to its parent option (e.g., LAD)
+    // so that only the parent is ever selected (accessibility-friendly)
+    promoteApiChildToParent = false,
 
     ...attributes
   }: {
@@ -195,6 +198,7 @@
 
     // Behavioural tweaks
     resetApiSuggestionsAfterSelection?: boolean;
+    promoteApiChildToParent?: boolean;
 
     // Bindable state props for external synchronization
     // Use these to sync color state with other components
@@ -218,11 +222,62 @@
   let debounceTimer: any = null;
   let lastQuery = "";
   const baseNoChoicesText = "No choices to choose from";
+  let isProcessingPromotion = false;
+
+  // Track context for promoted items (postcode -> LAD promotions)
+  const promotedItemContext = $state(new Map<string, string>());
+
+  // Dev inspect: track selection history without logging proxies
+  let __lastSnapshot: string[] = [];
+  let __history: Array<{
+    seq: number;
+    type: string;
+    prev: string[];
+    next: string[];
+  }> = [];
+  let __seq = 0;
+  $inspect(value).with((type: string, current: unknown) => {
+    const next = Array.isArray(current)
+      ? current.map((x) => String(x))
+      : current == null
+        ? []
+        : [String(current as any)];
+    const prev = __lastSnapshot;
+    __seq += 1;
+    __history.push({ seq: __seq, type, prev, next });
+    // Keep history bounded
+    if (__history.length > 50) __history.shift();
+    console.log("🧭 [inspect:value]", {
+      seq: __seq,
+      type,
+      prev,
+      next,
+      historyLen: __history.length,
+    });
+    __lastSnapshot = next.slice();
+  });
 
   // Helper function for getting group text
   function getGroupText(item: any): string | undefined {
     if (!groupKey || !item || typeof item !== "object") return undefined;
-    return item[groupKey] ? String(item[groupKey]) : undefined;
+
+    // Check for promoted context first (for items that were promoted from postcode to LAD)
+    if (promotedItemContext.has(String(item.value))) {
+      const context = promotedItemContext.get(String(item.value));
+      console.log("🏷️ Found promotion context for", item.value, "→", context);
+      return context;
+    }
+
+    const regularContext = item[groupKey] ? String(item[groupKey]) : undefined;
+    if (regularContext) {
+      console.log(
+        "🏷️ Found regular context for",
+        item.value,
+        "→",
+        regularContext,
+      );
+    }
+    return regularContext;
   }
 
   // Helper function to ensure group text is applied to choices
@@ -345,6 +400,8 @@
     return color;
   }
 
+  // rollbackColorAssignmentForValue removed; no transient child is created now
+
   // Computed values for component configuration
   let computedPlaceholderText = $derived(
     placeholderText || (multiple ? "Select all that apply" : "Select one"),
@@ -372,6 +429,9 @@
     raw?: any;
   };
   const staticChoices = $derived.by<ChoiceItem[]>(() => {
+    // Include promotedItemContext.size to make this reactive to promotion changes
+    promotedItemContext.size;
+
     /** @type {ChoiceItem[]} */
     const flattened: ChoiceItem[] = [];
     // Include enhancedItems() first (single-select placeholder support)
@@ -436,9 +496,9 @@
 
   // Determine component configuration type
   const hasApi = Boolean(source_url && source_key);
-  const hasStatic = staticChoices.length > (multiple ? 0 : 1); // (>1 if single because of placeholder)
-  const isDual = hasApi && hasStatic;
-  const isOptionsOnly = !hasApi && hasStatic;
+  const hasStatic = $derived(staticChoices.length > (multiple ? 0 : 1)); // (>1 if single because of placeholder)
+  const isDual = $derived(hasApi && hasStatic);
+  const isOptionsOnly = $derived(!hasApi && hasStatic);
 
   // Decide which search mode to use based on query and configuration
   function decideMode(query: string): Mode {
@@ -609,43 +669,6 @@
     return label;
   }
 
-  // Resolve the parent LAD for a selected postcode value. Uses provided resolver first,
-  // then falls back to postcodes.io single lookup when available.
-  async function resolveParentOfSelectedChild(
-    selected: string | number,
-  ): Promise<{ value: string | number; label?: string } | null> {
-    try {
-      if (typeof selectedChildParentResolver === "function") {
-        const r = selectedChildParentResolver(selected);
-        if (r) return r;
-      }
-    } catch (e) {
-      console.warn("⚠️ selectedChildParentResolver error:", e);
-    }
-
-    // Best-effort fallback for postcodes.io
-    try {
-      if (
-        typeof selected === "string" &&
-        typeof source_url === "string" &&
-        /postcodes\.io\/postcodes\/?$/.test(source_url)
-      ) {
-        const pc = selected.replace(/\s+/g, "");
-        const url = `${source_url}${encodeURIComponent(pc)}`;
-        const res = await fetch(url);
-        const json = await res.json();
-        const result = json?.result;
-        const code = result?.codes?.lau2 || result?.codes?.lad;
-        const label = result?.admin_district ?? undefined;
-        if (code) return { value: code, label };
-      }
-    } catch (e) {
-      console.warn("⚠️ Fallback parent resolution failed:", e);
-    }
-
-    return null;
-  }
-
   async function fetchApiChoices(query: string): Promise<ChoiceItem[]> {
     const url = buildApiUrl(query);
     if (!url) return [];
@@ -662,8 +685,9 @@
       const safeLabel = escapeHtml(label);
       const safeGroup = groupText ? escapeHtml(groupText) : "";
 
+      // Keep CHILD (e.g. postcode) as value so it never collides with static LAD values
       return {
-        value: toValue(entry, label),
+        value: label,
         label: safeGroup
           ? `<span class="choices__item-label">
                <span class="choices__item-main">${safeLabel}</span>
@@ -1252,19 +1276,35 @@
               const showRemove =
                 isMulti && this.config.removeItemButton && !data.disabled;
 
-              // Circle
+              // If this selected item was promoted, render parent label + context
+              const meta = (data as any)?.customProperties;
+              const hasParent = meta && meta.parentValue && meta.parentLabel;
+
+              // Circle (color keyed by parent if present, else extract parent from composite value)
               let circle = "";
               if (enableSelectedItemCircles && isMulti) {
-                const color = colorForValue(data.value); // ✅ value-only, stable
+                let colorKey;
+                if (hasParent) {
+                  colorKey = meta.parentValue;
+                } else if (String(data.value).includes("::")) {
+                  // Extract parent from composite value for color consistency
+                  colorKey = String(data.value).split("::")[0];
+                } else {
+                  colorKey = data.value;
+                }
+                const color = colorForValue(colorKey);
                 circle = `<span class="choices__item-circle" style="background:${color}"></span>`;
-                console.log("🎨 Adding circle with color:", {
-                  value: data.value,
-                  color,
-                });
               }
 
               // Label
-              const labelHtml = allowHTML ? data.label : esc(data.label);
+              const displayLabel = hasParent
+                ? `<span class="choices__item-label">
+                     <span class="choices__item-main">${escapeHtml(meta.parentLabel)}</span>
+                     <span class="gem-c-select-with-search__suggestion-group">${escapeHtml(`(containing ${meta.childLabel ?? data.value})`)}</span>
+                   </span>`
+                : allowHTML
+                  ? data.label
+                  : esc(data.label);
 
               // Remove button (same markup Choices normally generates)
               const removeBtn = showRemove
@@ -1282,7 +1322,7 @@
                       ${showRemove ? "data-deletable" : ""}
                       ${data.active ? 'aria-selected="true"' : ""}
                       ${data.disabled ? 'aria-disabled="true"' : ""}>
-                    ${circle}${labelHtml}${removeBtn}
+                    ${circle}${displayLabel}${removeBtn}
                  </div>`,
               );
             },
@@ -1364,12 +1404,36 @@
         config: choicesInstance.config,
       });
 
-      // Handle value changes from Choices.js
-      selectElement.addEventListener("change", handleChoicesChange);
+      // Initialize static choices
+      choicesInstance.setChoices(staticChoices, "value", "label", true);
+
+      // Keep the bound value in sync by reading from the Choices instance
+      selectElement.addEventListener("change", async (_event: Event) => {
+        handleChoicesChange(_event);
+      });
 
       // Listen for choice selection to reset search
-      selectElement.addEventListener("choice", () => {
+      selectElement.addEventListener("choice", (ev: any) => {
         console.log("🎯 Choice selected, resetting search");
+
+        // Check if this was a promoted choice and store context
+        const choice = ev?.detail?.choice;
+        if (
+          choice?.customProperties?.isPromoted &&
+          choice.customProperties.parentValue &&
+          choice.customProperties.childLabel
+        ) {
+          const parentValue = choice.customProperties.parentValue;
+          const childLabel = choice.customProperties.childLabel;
+          const context = `(containing ${childLabel})`;
+          promotedItemContext.set(parentValue, context);
+          console.log("🏷️ Stored promotion context:", {
+            parentValue,
+            childLabel,
+            context,
+          });
+        }
+
         // When an item is selected, clear the search and show all unselected options
         if (searchInputElement) {
           searchInputElement.value = "";
@@ -1566,6 +1630,8 @@
                   })),
                 });
 
+                // Note: No need to build child->parent map anymore since promotion happens at data-time
+
                 // Determine if the query is a full postcode (used to gate messages)
                 const isFullPostcode = looksLikePostcode(q);
 
@@ -1648,10 +1714,41 @@
                           return;
                         }
                         {
+                          // Check if any selected postcode maps to the same LAD
                           const coverParents = await Promise.all(
-                            (selectedValues || []).map((sv) =>
-                              resolveParentOfSelectedChild(sv),
-                            ),
+                            (selectedValues || []).map(async (sv) => {
+                              try {
+                                if (
+                                  typeof selectedChildParentResolver ===
+                                  "function"
+                                ) {
+                                  const r = selectedChildParentResolver(sv);
+                                  if (r) return r;
+                                }
+                                // Fallback for postcodes.io
+                                if (
+                                  typeof sv === "string" &&
+                                  typeof source_url === "string" &&
+                                  /postcodes\.io\/postcodes\/?$/.test(
+                                    source_url,
+                                  )
+                                ) {
+                                  const pc = sv.replace(/\s+/g, "");
+                                  const url = `${source_url}${encodeURIComponent(pc)}`;
+                                  const res = await fetch(url);
+                                  const json = await res.json();
+                                  const result = json?.result;
+                                  const code =
+                                    result?.codes?.lau2 || result?.codes?.lad;
+                                  const label =
+                                    result?.admin_district ?? undefined;
+                                  if (code) return { value: code, label };
+                                }
+                              } catch (e) {
+                                console.warn("⚠️ Parent resolution failed:", e);
+                              }
+                              return null;
+                            }),
                           );
                           const idx = coverParents.findIndex(
                             (rel) =>
@@ -1690,9 +1787,35 @@
                   let selectedParentSet = new Set<string>();
                   try {
                     const rels = await Promise.all(
-                      (selectedValues || []).map((sv) =>
-                        resolveParentOfSelectedChild(sv),
-                      ),
+                      (selectedValues || []).map(async (sv) => {
+                        try {
+                          if (
+                            typeof selectedChildParentResolver === "function"
+                          ) {
+                            const r = selectedChildParentResolver(sv);
+                            if (r) return r;
+                          }
+                          // Fallback for postcodes.io
+                          if (
+                            typeof sv === "string" &&
+                            typeof source_url === "string" &&
+                            /postcodes\.io\/postcodes\/?$/.test(source_url)
+                          ) {
+                            const pc = sv.replace(/\s+/g, "");
+                            const url = `${source_url}${encodeURIComponent(pc)}`;
+                            const res = await fetch(url);
+                            const json = await res.json();
+                            const result = json?.result;
+                            const code =
+                              result?.codes?.lau2 || result?.codes?.lad;
+                            const label = result?.admin_district ?? undefined;
+                            if (code) return { value: code, label };
+                          }
+                        } catch (e) {
+                          console.warn("⚠️ Parent resolution failed:", e);
+                        }
+                        return null;
+                      }),
                     );
                     for (const r of rels)
                       if (r && r.value != null)
@@ -1911,16 +2034,70 @@
                   // We have new, unselected results to show.
                   // Don't set noChoicesText when we have results - let Choices.js handle it
 
-                  // Ensure group text is applied to API choices
-                  const apiChoicesWithGroupText = ensureGroupTextApplied(
-                    filteredByParent.map((c) => ({
+                  let finalChoices;
+
+                  // If promotion is enabled, construct parent-valued choices at data time
+                  if (
+                    promoteApiChildToParent &&
+                    typeof apiParentResolver === "function"
+                  ) {
+                    console.log(
+                      "🔄 Building parent-valued API choices (promotion at data time)",
+                    );
+
+                    // Map every API record to a parent-valued choice with composite unique values
+                    // This ensures all postcodes show in dropdown while mapping to parent on selection
+                    const selectedSet = new Set(selectedValues.map(String));
+                    finalChoices = filteredByParent
+                      .map((c) => {
+                        try {
+                          const parent = apiParentResolver((c as any).raw);
+                          if (parent && parent.value != null) {
+                            const parentValue = String(parent.value);
+                            const childValue = String(c.value);
+                            // Use composite value to ensure uniqueness while storing parent info
+                            const compositeValue = `${parentValue}::${childValue}`;
+                            return {
+                              value: compositeValue, // composite value ensures uniqueness
+                              label: c.label, // keep postcode in label
+                              customProperties: {
+                                parentValue,
+                                parentLabel: parent.label || parentValue,
+                                childLabel: c.labelPlain ?? childValue,
+                                isPromoted: true,
+                              },
+                            };
+                          }
+                        } catch (e) {
+                          console.warn("⚠️ Failed to resolve parent:", e);
+                        }
+                        // Fallback: no parent — keep child as-is
+                        return { value: String(c.value), label: c.label };
+                      })
+                      .filter((ch) => {
+                        // For promoted choices, check if parent is already selected
+                        // For regular choices, check if child is already selected
+                        const meta = (ch as any).customProperties;
+                        if (meta?.isPromoted) {
+                          return !selectedSet.has(meta.parentValue);
+                        }
+                        return !selectedSet.has(String(ch.value));
+                      });
+                    console.log(
+                      "✅ Built parent-valued API choices:",
+                      finalChoices.length,
+                    );
+                  } else {
+                    // No promotion - use original API choices
+                    finalChoices = filteredByParent.map((c) => ({
                       value: String(c.value),
                       label: c.label,
-                    })),
-                  );
+                    }));
+                  }
 
+                  // Render API choices as-is so the dropdown shows postcodes while values are LAD codes
                   choicesInstance.setChoices(
-                    apiChoicesWithGroupText,
+                    finalChoices,
                     "value",
                     "label",
                     true,
@@ -1929,10 +2106,7 @@
                   // Custom templates are automatically applied when setChoices is called
                   // No need for additional refresh calls
 
-                  console.log(
-                    "✅ Set new API choices:",
-                    filteredByParent.length,
-                  );
+                  console.log("✅ Set final API choices:", finalChoices.length);
                 }
               } catch (e) {
                 console.error("❌ Failed to fetch API choices:", e);
@@ -2175,28 +2349,66 @@
 
   // Handle changes from Choices.js
   function handleChoicesChange(event: Event) {
-    const target = event.target as HTMLSelectElement;
-    console.log("🔄 Choices change event:", {
-      event: event.type,
-      target: target.tagName,
-      value: target.value,
-      selectedOptions: Array.from(target.selectedOptions).map((opt) => ({
-        value: opt.value,
-        text: opt.text,
-        selected: opt.selected,
-      })),
-      multiple: target.multiple,
-    });
+    if (!choicesInstance) return;
+
+    // Read values directly from Choices.js instance for accurate state
+    const raw = choicesInstance.getValue(true);
+    console.log("🔄 Choices change event - raw getValue:", raw);
 
     if (multiple) {
-      const selectedValues = Array.from(target.selectedOptions).map(
-        (option) => option.value,
-      );
-      console.log("📝 Setting multiple value:", selectedValues);
-      value = selectedValues;
+      const arr = Array.isArray(raw) ? raw : raw ? [raw] : [];
+      // Extract parent values from composite values for promoted choices
+      const processedValues = arr.map((x: any) => {
+        const val = String(x.value ?? x);
+        // Check if this is a composite value from promotion
+        if (val.includes("::")) {
+          const [parentValue, childLabel] = val.split("::");
+          // Persist context so the chip can render parent + (containing child)
+          try {
+            if (parentValue && childLabel) {
+              const context = `(containing ${childLabel})`;
+              promotedItemContext.set(parentValue, context);
+              console.log("🏷️ Stored promotion context (change):", {
+                parentValue,
+                childLabel,
+                context,
+              });
+            }
+          } catch {}
+          console.log(
+            "🔄 Extracting parent from composite:",
+            val,
+            "→",
+            parentValue,
+          );
+          return parentValue;
+        }
+        return val;
+      });
+      console.log("📝 Setting multiple value:", processedValues);
+      value = processedValues;
     } else {
-      console.log("📝 Setting single value:", target.value);
-      value = target.value;
+      const val = raw ? String((raw as any).value ?? raw) : "";
+      // Extract parent value from composite if needed and persist context
+      if (val.includes("::")) {
+        const [parentValue, childLabel] = val.split("::");
+        try {
+          if (parentValue && childLabel) {
+            const context = `(containing ${childLabel})`;
+            promotedItemContext.set(parentValue, context);
+            console.log("🏷️ Stored promotion context (change single):", {
+              parentValue,
+              childLabel,
+              context,
+            });
+          }
+        } catch {}
+        console.log("📝 Setting single value:", parentValue);
+        value = parentValue;
+      } else {
+        console.log("📝 Setting single value:", val);
+        value = val;
+      }
     }
   }
 
@@ -2212,10 +2424,85 @@
     if (choicesInstance && choicesInstance.initialised && value !== undefined) {
       if (multiple && Array.isArray(value)) {
         console.log("🔄 Updating multiple choices:", value);
+
+        // Clean up promotion context for items no longer selected
+        const currentValues = new Set(value.map(String));
+        for (const [contextKey] of promotedItemContext) {
+          if (!currentValues.has(contextKey)) {
+            console.log(
+              "🧹 Cleaning up promotion context for removed item:",
+              contextKey,
+            );
+            promotedItemContext.delete(contextKey);
+          }
+        }
+
+        // When value changes programmatically (e.g., postcode promotion), the choice object
+        // for the new value might not exist in the instance's current list (e.g., if it's
+        // showing API results). We need to merge our static "source of truth" with the
+        // current choices so that `setChoiceByValue` can find the item and render its chip.
+        const currentChoices = Array.isArray((choicesInstance as any)?.choices)
+          ? (choicesInstance as any).choices
+          : Array.isArray((choicesInstance as any)?._store?.choices)
+            ? (choicesInstance as any)._store.choices
+            : [];
+        const mergedChoices = new Map<string, any>();
+
+        // Prioritize static choices for labels and context
+        staticChoices.forEach((c) => mergedChoices.set(String(c.value), c));
+        // Add any other choices (e.g., from API) that aren't static
+        for (const c of currentChoices) {
+          const key = String((c as any).value);
+          if (!mergedChoices.has(key)) {
+            mergedChoices.set(key, c);
+          }
+        }
+
+        // For any selected value with promotion context, manually build its choice object
+        // This ensures the chip renders correctly even if staticChoices hasn't re-derived
+        if (Array.isArray(value)) {
+          value.forEach((val) => {
+            const key = String(val);
+            if (promotedItemContext.has(key)) {
+              const staticChoice = staticChoices.find(
+                (c) => String(c.value) === key,
+              );
+              if (staticChoice) {
+                const context = promotedItemContext.get(key)!;
+                const newLabel = `<span class="choices__item-label">
+                   <span class="choices__item-main">${escapeHtml(staticChoice.labelPlain ?? "")}</span>
+                   <span class="gem-c-select-with-search__suggestion-group">${escapeHtml(context)}</span>
+                 </span>`;
+                mergedChoices.set(key, {
+                  ...staticChoice,
+                  label: newLabel,
+                  customProperties: {
+                    parentValue: key,
+                    parentLabel:
+                      staticChoice.labelPlain ?? String(staticChoice.value),
+                    childLabel: context.replace(/^\(containing |\)$/g, ""), // Extract just the postcode from "(containing TW5 0AA)"
+                  },
+                });
+                console.log("🛠️ Manually crafted choice for promoted item:", {
+                  key,
+                  newLabel,
+                  context,
+                });
+              }
+            }
+          });
+        }
+
+        // Silently update the full list of available choices.
+        // This ensures the instance knows about the promoted LAD option.
+        choicesInstance.setChoices(
+          Array.from(mergedChoices.values()),
+          "value",
+          "label",
+          true,
+        );
         choicesInstance.removeActiveItems();
-        value.forEach((val: string | number) => {
-          choicesInstance.setChoiceByValue(String(val));
-        });
+        choicesInstance.setChoiceByValue(value.map(String));
       } else if (!multiple && !Array.isArray(value)) {
         console.log("🔄 Updating single choice:", value);
         choicesInstance.setChoiceByValue(String(value));
@@ -2223,19 +2510,46 @@
     }
   });
 
+  // Update Choices.js when items change externally (e.g., when options are modified with context)
+  $effect(() => {
+    if (!choicesInstance || !choicesInstance.initialised) return;
+
+    // Watch for changes to items and groups
+    const itemsLength = items.length;
+    const groupsLength = groups.length;
+    const staticChoicesLength = staticChoices.length;
+
+    console.log("🔄 Items changed externally:", {
+      itemsLength,
+      groupsLength,
+      staticChoicesLength,
+      currentMode,
+    });
+
+    // Only refresh static choices if we're in options mode or options-only
+    if (currentMode === "options" || isOptionsOnly) {
+      setTimeout(() => {
+        if (choicesInstance && choicesInstance.initialised) {
+          console.log("🔄 Refreshing static choices due to items change");
+          resetToStaticChoices();
+        }
+      }, 0);
+    }
+  });
+
   // Cleanup
   onDestroy(() => {
     console.log("🧹 MultiSelectSearchAutocomplete: onDestroy called");
     if (choicesInstance) {
-      // No more MutationObserver to clean up
       selectElement?.removeEventListener("change", handleChoicesChange);
       selectElement?.removeEventListener("choice", () => {});
+
       choicesInstance.destroy();
       console.log("✅ Choices instance destroyed");
     }
   });
 
-  // Log component state changes
+  // Log component state changes (using $inspect to avoid console warnings)
   $inspect(
     id,
     name,

--- a/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
+++ b/src/lib/components/ui/MultiSelectSearchAutocomplete.svelte
@@ -1216,7 +1216,7 @@
 
               // Color calculation (needed for both circles and border matching)
               let color = "#b1b4b6"; // Default fallback color
-              
+
               // Circle (color keyed by parent if present, else extract parent from composite value)
               let colorKey;
               if (enableSelectedItemCircles && isMulti) {
@@ -1231,7 +1231,7 @@
                 color = colorForValue(colorKey);
               }
 
-              // Circle 
+              // Circle
               let circle = "";
               if (enableSelectedItemCircles && isMulti) {
                 circle = `<span class="choices__item-circle" style="background:${color}"></span>`;
@@ -1256,9 +1256,10 @@
                 : "";
 
               // Border styling for matching circle color
-              const borderStyle = matchBorderToCircleColor && enableSelectedItemCircles && isMulti 
-                ? `style="border: 2px solid ${color}; box-shadow: none;"` 
-                : "";
+              const borderStyle =
+                matchBorderToCircleColor && enableSelectedItemCircles && isMulti
+                  ? `style="border: 2px solid ${color}; box-shadow: none;"`
+                  : "";
 
               return strToEl(
                 `<div class="${classes}"

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -133,6 +133,8 @@
    */
   let selectedValue = $state([]);
   let selectedValues = $state([]);
+  let bindSelectedItemIndexMap = $state(new Map());
+  let bindNextSelectionIndex = $state(0);
 
   /**
    * ! Step 3 - Add your props
@@ -240,7 +242,7 @@
         name: "value",
         category: "Core attributes",
         isBinded: true,
-        value: selectedValue,
+        value: null,
         description: {
           markdown: true,
           arr: [
@@ -721,7 +723,8 @@
         name: "bindSelectedItemIndexMap",
         category: "Bindable state",
         propType: "fixed",
-        value: undefined,
+        value: null,
+        isBinded: true,
         description: {
           markdown: true,
           arr: [
@@ -733,7 +736,8 @@
         name: "bindNextSelectionIndex",
         category: "Bindable state",
         propType: "fixed",
-        value: undefined,
+        value: null,
+        isBinded: true,
         description: {
           markdown: true,
           arr: [
@@ -791,7 +795,13 @@
    *  &&     The getValue() function can be helpful for deriving props based on the value of $state() prop.
    */
 
-  let derivedParametersObject = $derived({});
+  let derivedParametersObject = $derived({
+    value: selectedValue,
+    bindSelectedItemIndexMap: bindSelectedItemIndexMap instanceof Map 
+      ? Object.fromEntries(bindSelectedItemIndexMap) 
+      : bindSelectedItemIndexMap,
+    bindNextSelectionIndex: bindNextSelectionIndex
+  });
 
   /**
    * DONOTTOUCH *
@@ -885,6 +895,8 @@
     {#key [parametersObject.removeItemButton, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette].join("|")}
       <MultiSelectSearchAutocomplete
         bind:value={selectedValue}
+        bind:bindSelectedItemIndexMap={bindSelectedItemIndexMap}
+        bind:bindNextSelectionIndex={bindNextSelectionIndex}
         {...parametersObject}
       ></MultiSelectSearchAutocomplete>
     {/key}

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -354,7 +354,7 @@
       {
         name: "searchResultLimit",
         category: "Search options",
-        value: 100,
+        value: 6,
         description: {
           markdown: true,
           arr: [`Maximum number of options to show in search results.`],
@@ -1018,7 +1018,7 @@
  -->
 {#snippet Component()}
   <div class="p-8">
-    {#key [parametersObject.removeItemButton, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette].join("|")}
+    {#key [parametersObject.removeItemButton, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.searchPlaceholder, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette].join("|")}
       <MultiSelectSearchAutocomplete
         bind:value={selectedValue}
         bind:bindSelectedItemIndexMap

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -611,7 +611,7 @@
         description: {
           markdown: true,
           arr: [
-            `Complete GOV.UK Design System color palette (19 colors) with infinite extension capability. Uses the full official GDS palette first, then automatically generates additional unique colors using proven data visualization algorithms (similar to Plotly.js) when more than 19 selections are made. This ensures every selection gets a unique color while maintaining accessibility standards.`,
+            `Complete GOV.UK Design System color palette (19 colors). Colors are assigned based on selection order (not deterministic by item value), but each item remembers its assigned color. When more than 19 items are selected, colors cycle back to the beginning of the palette.`,
           ],
         },
       },

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -326,7 +326,11 @@
         value: "Search in list",
         description: {
           markdown: true,
-          arr: [`Placeholder text shown in the search input field.`],
+          arr: [
+            `<strong>Placeholder text for the search query input field in single select mode only.</strong> This text appears inside the search input box to guide users on what to type. Due to Choices.js library limitations, this property only works with single select (<code>multiple: false</code>). Has no effect in multiple select mode.`,
+            `<strong>Dependencies:</strong> Only functional with single select mode. Choices.js does not support search placeholders for multiple select elements.`,
+            `<strong>Default:</strong> <code>"Search in list"</code> (single select only)`,
+          ],
         },
       },
       {

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -388,6 +388,17 @@
           ],
         },
       },
+      {
+        name: "showSearchIcon",
+        category: "Search options",
+        value: true,
+        description: {
+          markdown: true,
+          arr: [
+            `<strong>Whether to show the search icon button.</strong> When <code>true</code>, displays a search icon on the right side of the input. When <code>false</code>, hides the search icon for a cleaner appearance.`,
+          ],
+        },
+      },
 
       // Styling and Layout
       {
@@ -1037,7 +1048,7 @@
  -->
 {#snippet Component()}
   <div class="p-8">
-    {#key [parametersObject.removeItemButton, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.searchPlaceholder, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette, parametersObject.disabled, parametersObject.fullWidth].join("|")}
+    {#key [parametersObject.removeItemButton, parametersObject.showSearchIcon, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.searchPlaceholder, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette, parametersObject.disabled, parametersObject.fullWidth].join("|")}
       <MultiSelectSearchAutocomplete
         bind:value={selectedValue}
         bind:bindSelectedItemIndexMap

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -367,7 +367,9 @@
         description: {
           markdown: true,
           arr: [
-            `Whether to show remove buttons on selected items. Defaults to true for multiple select.`,
+            `<strong>Whether to show X remove buttons on selected items (chips/pills).</strong> When <code>true</code>, selected items display with clickable X buttons for removal. When <code>false</code>, selected items appear without remove buttons (can only be removed by deselecting from dropdown).`,
+            `<strong>Dependencies:</strong> Only applies to multiple select mode (<code>multiple: true</code>). In single select mode, there are no selected item chips to display remove buttons on.`,
+            `<strong>Default:</strong> <code>true</code> for multiple select mode (automatically computed based on <code>multiple</code> prop if not explicitly set)`,
           ],
         },
       },

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -797,10 +797,11 @@
 
   let derivedParametersObject = $derived({
     value: selectedValue,
-    bindSelectedItemIndexMap: bindSelectedItemIndexMap instanceof Map 
-      ? Object.fromEntries(bindSelectedItemIndexMap) 
-      : bindSelectedItemIndexMap,
-    bindNextSelectionIndex: bindNextSelectionIndex
+    bindSelectedItemIndexMap:
+      bindSelectedItemIndexMap instanceof Map
+        ? Object.fromEntries(bindSelectedItemIndexMap)
+        : bindSelectedItemIndexMap,
+    bindNextSelectionIndex: bindNextSelectionIndex,
   });
 
   /**
@@ -895,8 +896,8 @@
     {#key [parametersObject.removeItemButton, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette].join("|")}
       <MultiSelectSearchAutocomplete
         bind:value={selectedValue}
-        bind:bindSelectedItemIndexMap={bindSelectedItemIndexMap}
-        bind:bindNextSelectionIndex={bindNextSelectionIndex}
+        bind:bindSelectedItemIndexMap
+        bind:bindNextSelectionIndex
         {...parametersObject}
       ></MultiSelectSearchAutocomplete>
     {/key}

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -393,7 +393,7 @@
       {
         name: "formGroupClasses",
         category: "Styling and layout",
-        value: "",
+        value: "w-1/3",
         description: {
           markdown: true,
           arr: [`Additional CSS classes for the form group wrapper.`],
@@ -405,7 +405,9 @@
         value: false,
         description: {
           markdown: true,
-          arr: [`Makes the select element full width if true.`],
+          arr: [
+            `<strong>Makes the component take full width when true.</strong> This appends <code>w-full</code> class to the <code>formGroupClasses</code>, overriding any width restrictions. Works for both the enhanced Choices.js version and the fallback <code>&lt;select&gt;</code> element.`,
+          ],
         },
       },
       {
@@ -1035,7 +1037,7 @@
  -->
 {#snippet Component()}
   <div class="p-8">
-    {#key [parametersObject.removeItemButton, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.searchPlaceholder, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette].join("|")}
+    {#key [parametersObject.removeItemButton, parametersObject.multiple, parametersObject.allowHTML, parametersObject.shouldSort, parametersObject.searchResultLimit, parametersObject.searchPlaceholder, parametersObject.choicesItemBackgroundColor, parametersObject.choicesItemBorderColor, parametersObject.choicesItemTextColor, parametersObject.choicesItemDividerPadding, parametersObject.selectedItemCircleColor, parametersObject.enableSelectedItemCircles, parametersObject.selectedItemCircleColorPalette, parametersObject.disabled, parametersObject.fullWidth].join("|")}
       <MultiSelectSearchAutocomplete
         bind:value={selectedValue}
         bind:bindSelectedItemIndexMap

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -557,7 +557,7 @@
         description: {
           markdown: true,
           arr: [
-            `Color of the circle indicator shown on selected items in the button (not in dropdown options).`,
+            `Fallback color for circle indicators on selected items. **Multi-select only** - circles are only shown when both <code>enableSelectedItemCircles</code> is true and <code>multiple</code> is true. In practice, actual colors come from <code>selectedItemCircleColorPalette</code> which provides unique colors for each selection.`,
           ],
         },
       },

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -408,11 +408,11 @@
       {
         name: "placeholderText",
         category: "Other options",
-        value: undefined,
+        value: "placeholder",
         description: {
           markdown: true,
           arr: [
-            `Custom placeholder text. If not provided, defaults to "Select all that apply" for multiple select or "Select one" for single select.`,
+            `Custom placeholder text for single select mode. If not provided, defaults to "Select all that apply" for multiple select or "Select one" for single select.`,
           ],
         },
       },
@@ -423,6 +423,71 @@
         description: {
           markdown: true,
           arr: [`Additional options to pass to the Choices.js library.`],
+        },
+      },
+
+      // API and Dynamic Options
+      {
+        name: "source_url",
+        category: "API options",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`URL for fetching dynamic options from an API.`],
+        },
+      },
+      {
+        name: "source_key",
+        category: "API options",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Key to extract data from API response.`],
+        },
+      },
+      {
+        name: "source_property",
+        category: "API options",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Property to use as the display text from API data.`],
+        },
+      },
+      {
+        name: "sourceSelector",
+        category: "API options",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to decide whether to use 'api' or 'options' for a given query.`],
+        },
+      },
+      {
+        name: "minLength",
+        category: "API options",
+        value: 0,
+        description: {
+          markdown: true,
+          arr: [`Minimum length before triggering API search.`],
+        },
+      },
+      {
+        name: "tTooShort",
+        category: "API options",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to generate message when query is too short.`],
+        },
+      },
+      {
+        name: "groupKey",
+        category: "API options",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Key for displaying additional context in options.`],
         },
       },
 
@@ -464,6 +529,24 @@
         },
       },
       {
+        name: "choicesItemBorderRadius",
+        category: "Choices.js styling",
+        value: "0",
+        description: {
+          markdown: true,
+          arr: [`Border radius for dropdown items.`],
+        },
+      },
+      {
+        name: "selectedChipBackgroundColor",
+        category: "Choices.js styling",
+        value: "#f3f2f1",
+        description: {
+          markdown: true,
+          arr: [`Background color specifically for selected chips/pills.`],
+        },
+      },
+      {
         name: "selectedItemCircleColor",
         category: "Choices.js styling",
         value: "#1d70b8",
@@ -482,6 +565,17 @@
           markdown: true,
           arr: [
             `Enable or disable the colored circle indicators on selected items.`,
+          ],
+        },
+      },
+      {
+        name: "matchBorderToCircleColor",
+        category: "Choices.js styling",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `Enable border colors to match circle colors for selected items.`,
           ],
         },
       },
@@ -515,6 +609,120 @@
           arr: [
             `Complete GOV.UK Design System color palette (19 colors) with infinite extension capability. Uses the full official GDS palette first, then automatically generates additional unique colors using proven data visualization algorithms (similar to Plotly.js) when more than 19 selections are made. This ensures every selection gets a unique color while maintaining accessibility standards.`,
           ],
+        },
+      },
+
+      // Advanced Cross-Selection Features
+      {
+        name: "apiParentResolver",
+        category: "Advanced features",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to resolve parent options from API data.`],
+        },
+      },
+      {
+        name: "staticChildrenResolver",
+        category: "Advanced features",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to resolve child options from static data.`],
+        },
+      },
+      {
+        name: "selectedChildParentResolver",
+        category: "Advanced features", 
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to resolve parent from selected child value.`],
+        },
+      },
+      {
+        name: "tApiChildInSelectedParent",
+        category: "Advanced features",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to generate message when API child is in selected parent.`],
+        },
+      },
+      {
+        name: "tApiChildCoveredBySelectedChild",
+        category: "Advanced features",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to generate message when API child is covered by selected child.`],
+        },
+      },
+      {
+        name: "tStaticParentContainsSelectedChildren",
+        category: "Advanced features",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to generate message when static parent contains selected children.`],
+        },
+      },
+      {
+        name: "tPartialPostcodeInSelectedParent",
+        category: "Advanced features",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Function to generate message for partial postcode in selected parent.`],
+        },
+      },
+
+      // Behavioral Options
+      {
+        name: "resetApiSuggestionsAfterSelection",
+        category: "Behavioral options",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [`Reset API suggestions after making a selection.`],
+        },
+      },
+      {
+        name: "promoteApiChildToParent",
+        category: "Behavioral options",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [`Promote API child (e.g., postcode) to its parent option (e.g., LAD).`],
+        },
+      },
+
+      // Bindable State Props
+      {
+        name: "bindSelectedItemIndexMap",
+        category: "Bindable state",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Bindable map of item values to their color indices for external synchronization.`],
+        },
+      },
+      {
+        name: "bindNextSelectionIndex",
+        category: "Bindable state",
+        propType: "fixed",
+        value: undefined,
+        description: {
+          markdown: true,
+          arr: [`Bindable next available color index for external synchronization.`],
         },
       },
     ]),

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -460,7 +460,9 @@
         value: undefined,
         description: {
           markdown: true,
-          arr: [`Function to decide whether to use 'api' or 'options' for a given query.`],
+          arr: [
+            `Function to decide whether to use 'api' or 'options' for a given query.`,
+          ],
         },
       },
       {
@@ -635,7 +637,7 @@
       },
       {
         name: "selectedChildParentResolver",
-        category: "Advanced features", 
+        category: "Advanced features",
         propType: "fixed",
         value: undefined,
         description: {
@@ -650,7 +652,9 @@
         value: undefined,
         description: {
           markdown: true,
-          arr: [`Function to generate message when API child is in selected parent.`],
+          arr: [
+            `Function to generate message when API child is in selected parent.`,
+          ],
         },
       },
       {
@@ -660,7 +664,9 @@
         value: undefined,
         description: {
           markdown: true,
-          arr: [`Function to generate message when API child is covered by selected child.`],
+          arr: [
+            `Function to generate message when API child is covered by selected child.`,
+          ],
         },
       },
       {
@@ -670,7 +676,9 @@
         value: undefined,
         description: {
           markdown: true,
-          arr: [`Function to generate message when static parent contains selected children.`],
+          arr: [
+            `Function to generate message when static parent contains selected children.`,
+          ],
         },
       },
       {
@@ -680,7 +688,9 @@
         value: undefined,
         description: {
           markdown: true,
-          arr: [`Function to generate message for partial postcode in selected parent.`],
+          arr: [
+            `Function to generate message for partial postcode in selected parent.`,
+          ],
         },
       },
 
@@ -700,7 +710,9 @@
         value: false,
         description: {
           markdown: true,
-          arr: [`Promote API child (e.g., postcode) to its parent option (e.g., LAD).`],
+          arr: [
+            `Promote API child (e.g., postcode) to its parent option (e.g., LAD).`,
+          ],
         },
       },
 
@@ -712,7 +724,9 @@
         value: undefined,
         description: {
           markdown: true,
-          arr: [`Bindable map of item values to their color indices for external synchronization.`],
+          arr: [
+            `Bindable map of item values to their color indices for external synchronization.`,
+          ],
         },
       },
       {
@@ -722,7 +736,9 @@
         value: undefined,
         description: {
           markdown: true,
-          arr: [`Bindable next available color index for external synchronization.`],
+          arr: [
+            `Bindable next available color index for external synchronization.`,
+          ],
         },
       },
     ]),

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -621,41 +621,93 @@
         name: "apiParentResolver",
         category: "Advanced features",
         propType: "fixed",
-        value: undefined,
+        value: function(apiItem) {
+          // Extract parent value from API response
+          // Example: return apiItem.codes?.lau2 || apiItem.lau2;
+          return apiItem.parentCode;
+        },
+        functionElements: {
+          functionAsString: `function(apiItem) {
+  // Extract parent value from API response
+  // Example: return apiItem.codes?.lau2 || apiItem.lau2;
+  return apiItem.parentCode;
+}`,
+        },
         description: {
           markdown: true,
-          arr: [`Function to resolve parent options from API data.`],
+          arr: [
+            `<strong>Function to resolve parent options from API data.</strong> Required when using dual-mode (API + static options) with cross-selection logic. Receives API response item, should return parent identifier for coverage checking.`,
+            `<strong>Dependencies:</strong> Used with dual-mode configurations when both <code>source_url</code> and static <code>items</code> are provided.`,
+            `<strong>Default:</strong> <code>undefined</code> (no parent resolution)`,
+          ],
         },
       },
       {
         name: "staticChildrenResolver",
         category: "Advanced features",
         propType: "fixed",
-        value: undefined,
+        value: function(staticItem) {
+          // Extract child values from static option
+          // Example: return staticItem.children || [];
+          return staticItem.postcodes || [];
+        },
+        functionElements: {
+          functionAsString: `function(staticItem) {
+  // Extract child values from static option
+  // Example: return staticItem.children || [];
+  return staticItem.postcodes || [];
+}`,
+        },
         description: {
           markdown: true,
-          arr: [`Function to resolve child options from static data.`],
+          arr: [
+            `<strong>Function to resolve child options from static data.</strong> Used for hierarchical relationships where static options contain child items that should be checked against API selections.`,
+            `<strong>Dependencies:</strong> Used with dual-mode configurations when static options contain hierarchical data.`,
+            `<strong>Default:</strong> <code>undefined</code> (no child resolution)`,
+          ],
         },
       },
       {
         name: "selectedChildParentResolver",
         category: "Advanced features",
         propType: "fixed",
-        value: undefined,
+        value: function(selectedValue) {
+          // Resolve parent from selected child value
+          // Example: Look up postcode's LAD
+          return postcodeToLADMapping[selectedValue];
+        },
+        functionElements: {
+          functionAsString: `function(selectedValue) {
+  // Resolve parent from selected child value
+  // Example: Look up postcode's LAD
+  return postcodeToLADMapping[selectedValue];
+}`,
+        },
         description: {
           markdown: true,
-          arr: [`Function to resolve parent from selected child value.`],
+          arr: [
+            `<strong>Function to resolve parent from selected child value.</strong> Used to determine what parent option a selected child belongs to for coverage checking and conflict resolution.`,
+            `<strong>Dependencies:</strong> Used when dealing with child-parent relationships in selected values.`,
+            `<strong>Default:</strong> <code>undefined</code> (no parent resolution from selected values)`,
+          ],
         },
       },
       {
         name: "tApiChildInSelectedParent",
         category: "Advanced features",
         propType: "fixed",
-        value: undefined,
+        value: (child, parent) => `${child} is in ${parent}, which is already selected`,
+        functionElements: {
+          functionAsString: `function(child, parent) {
+  return \`\${child} is in \${parent}, which is already selected\`;
+}`,
+        },
         description: {
           markdown: true,
           arr: [
-            `Function to generate message when API child is in selected parent.`,
+            `<strong>Function to generate message when API child is in selected parent.</strong> Called when user searches for an API item (e.g., postcode) that belongs to an already selected parent option (e.g., LAD).`,
+            `<strong>Dependencies:</strong> Used with <code>apiParentResolver</code> when API items can be contained within static selections.`,
+            `<strong>Default:</strong> <code>(child, parent) => \`\${child} is in \${parent}, which is already selected\`</code>`,
           ],
         },
       },
@@ -663,11 +715,18 @@
         name: "tApiChildCoveredBySelectedChild",
         category: "Advanced features",
         propType: "fixed",
-        value: undefined,
+        value: (child, parent, selectedChild) => `${child} is in ${parent}, which is already covered by the selected postcode ${selectedChild}`,
+        functionElements: {
+          functionAsString: `function(child, parent, selectedChild) {
+  return \`\${child} is in \${parent}, which is already covered by the selected postcode \${selectedChild}\`;
+}`,
+        },
         description: {
           markdown: true,
           arr: [
-            `Function to generate message when API child is covered by selected child.`,
+            `<strong>Function to generate message when API child is covered by selected child.</strong> Called when user searches for an API item that belongs to the same parent as an already selected child item.`,
+            `<strong>Dependencies:</strong> Used with <code>apiParentResolver</code> and <code>selectedChildParentResolver</code> for child-parent conflict detection.`,
+            `<strong>Default:</strong> <code>(child, parent, selectedChild) => \`\${child} is in \${parent}, which is already covered by the selected postcode \${selectedChild}\`</code>`,
           ],
         },
       },
@@ -675,11 +734,18 @@
         name: "tStaticParentContainsSelectedChildren",
         category: "Advanced features",
         propType: "fixed",
-        value: undefined,
+        value: (parent, children) => `${parent} contains ${children.join(", ")}, which ${children.length > 1 ? "are" : "is"} already selected`,
+        functionElements: {
+          functionAsString: `function(parent, children) {
+  return \`\${parent} contains \${children.join(", ")}, which \${children.length > 1 ? "are" : "is"} already selected\`;
+}`,
+        },
         description: {
           markdown: true,
           arr: [
-            `Function to generate message when static parent contains selected children.`,
+            `<strong>Function to generate message when static parent contains selected children.</strong> Called when user tries to select a parent option that would encompass already selected child items.`,
+            `<strong>Dependencies:</strong> Used with <code>staticChildrenResolver</code> to check if parent options conflict with existing child selections.`,
+            `<strong>Default:</strong> <code>(parent, children) => \`\${parent} contains \${children.join(", ")}, which \${children.length > 1 ? "are" : "is"} already selected\`</code>`,
           ],
         },
       },
@@ -687,11 +753,18 @@
         name: "tPartialPostcodeInSelectedParent",
         category: "Advanced features",
         propType: "fixed",
-        value: undefined,
+        value: (partialPostcode, parent) => `Postcodes beginning ${partialPostcode}... are in ${parent}, which is already selected`,
+        functionElements: {
+          functionAsString: `function(partialPostcode, parent) {
+  return \`Postcodes beginning \${partialPostcode}... are in \${parent}, which is already selected\`;
+}`,
+        },
         description: {
           markdown: true,
           arr: [
-            `Function to generate message for partial postcode in selected parent.`,
+            `<strong>Function to generate message for partial postcode in selected parent.</strong> Called when <code>promoteApiChildToParent</code> is enabled and user searches partial postcode that belongs to already selected parent.`,
+            `<strong>Dependencies:</strong> Used when <code>promoteApiChildToParent</code> is true and partial postcode searches conflict with selected parents.`,
+            `<strong>Default:</strong> <code>(partialPostcode, parent) => \`Postcodes beginning \${partialPostcode}... are in \${parent}, which is already selected\`</code>`,
           ],
         },
       },

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -472,7 +472,7 @@
         name: "sourceSelector",
         category: "API options",
         propType: "fixed",
-        value: function(query, options) {
+        value: function (query, options) {
           // Default logic: use API when source_url/source_key present and query >= 3 chars
           return query.length >= 3 ? "api" : "options";
         },

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -410,11 +410,13 @@
       {
         name: "placeholderText",
         category: "Other options",
-        value: "placeholder",
+        value: "",
         description: {
           markdown: true,
           arr: [
-            `Custom placeholder text for single select mode. If not provided, defaults to "Select all that apply" for multiple select or "Select one" for single select.`,
+            `<strong>Custom placeholder text for single select mode only.</strong> This text appears as the initial/empty state option in the dropdown before any selections are made. Has no visible effect in multiple select mode.`,
+            `<strong>Dependencies:</strong> Only applies to single select mode (<code>multiple: false</code>). Ignored when <code>multiple: true</code>.`,
+            `<strong>Default:</strong> <code>"Select one"</code> for single select mode`,
           ],
         },
       },

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -404,7 +404,7 @@
       {
         name: "formGroupClasses",
         category: "Styling and layout",
-        value: "w-1/3",
+        value: "w-1/2",
         description: {
           markdown: true,
           arr: [`Additional CSS classes for the form group wrapper.`],

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -432,38 +432,62 @@
       {
         name: "source_url",
         category: "API options",
-        value: undefined,
+        value: "",
         description: {
           markdown: true,
-          arr: [`URL for fetching dynamic options from an API.`],
+          arr: [
+            `<strong>URL for fetching dynamic options from an API.</strong> When provided, enables API-based search functionality alongside or instead of static options. Component will make HTTP requests to this URL with query parameters.`,
+            `<strong>Dependencies:</strong> Works with <code>source_key</code> and <code>source_property</code> to parse API responses. Optional <code>sourceSelector</code> can control when API vs static options are used.`,
+            `<strong>Default:</strong> <code>undefined</code> (no API integration)`,
+          ],
         },
       },
       {
         name: "source_key",
         category: "API options",
-        value: undefined,
+        value: "",
         description: {
           markdown: true,
-          arr: [`Key to extract data from API response.`],
+          arr: [
+            `<strong>Key to extract data from API response.</strong> Specifies the property path in the API response that contains the array of options. Uses dot notation for nested properties.`,
+            `<strong>Dependencies:</strong> Required when <code>source_url</code> is provided and API response is not a direct array.`,
+            `<strong>Default:</strong> <code>undefined</code> (expects API response to be direct array)`,
+          ],
         },
       },
       {
         name: "source_property",
         category: "API options",
-        value: undefined,
+        value: "",
         description: {
           markdown: true,
-          arr: [`Property to use as the display text from API data.`],
+          arr: [
+            `<strong>Property to use as the display text from API data.</strong> Specifies which field from each API result item should be shown to users in the dropdown. If not provided, entire item will be converted to string.`,
+            `<strong>Dependencies:</strong> Used when <code>source_url</code> is provided to format API results for display.`,
+            `<strong>Default:</strong> <code>undefined</code> (uses entire item as display text)`,
+          ],
         },
       },
       {
         name: "sourceSelector",
         category: "API options",
-        value: undefined,
+        propType: "fixed",
+        value: function(query, options) {
+          // Default logic: use API when source_url/source_key present and query >= 3 chars
+          return query.length >= 3 ? "api" : "options";
+        },
+        functionElements: {
+          functionAsString: `function(query, options) {
+  // Default logic: use API when source_url/source_key present and query >= 3 chars
+  return query.length >= 3 ? "api" : "options";
+}`,
+        },
         description: {
           markdown: true,
           arr: [
-            `Function to decide whether to use 'api' or 'options' for a given query.`,
+            `<strong>Function to decide whether to use 'api' or 'options' for a given query.</strong> Controls whether to search static options or make API request based on user input. Returns either "api" or "options".`,
+            `<strong>Dependencies:</strong> Used when both <code>source_url</code> and static <code>items</code> are provided for dual-mode operation.`,
+            `<strong>Default:</strong> Uses API when query length >= 3 characters, otherwise uses static options`,
           ],
         },
       },
@@ -473,25 +497,43 @@
         value: 0,
         description: {
           markdown: true,
-          arr: [`Minimum length before triggering API search.`],
+          arr: [
+            `<strong>Minimum length before triggering API search.</strong> Prevents API calls for very short queries. When user input is shorter, shows <code>tTooShort</code> message instead of making API request.`,
+            `<strong>Dependencies:</strong> Used with <code>source_url</code> for API-based searching. Works with <code>tTooShort</code> function for user messaging.`,
+            `<strong>Default:</strong> <code>0</code> (no minimum length requirement)`,
+          ],
         },
       },
       {
         name: "tTooShort",
         category: "API options",
-        value: undefined,
+        propType: "fixed",
+        value: (n) => `Enter ${n} or more characters for suggestions`,
+        functionElements: {
+          functionAsString: `function(n) {
+  return \`Enter \${n} or more characters for suggestions\`;
+}`,
+        },
         description: {
           markdown: true,
-          arr: [`Function to generate message when query is too short.`],
+          arr: [
+            `<strong>Function to generate message when query is too short.</strong> Called when user input length is below <code>minLength</code> threshold. Receives the minimum required length as parameter.`,
+            `<strong>Dependencies:</strong> Used with <code>minLength</code> and <code>source_url</code> to provide user feedback for short queries.`,
+            `<strong>Default:</strong> <code>(n) => \`Enter \${n} or more characters for suggestions\`</code>`,
+          ],
         },
       },
       {
         name: "groupKey",
         category: "API options",
-        value: undefined,
+        value: "",
         description: {
           markdown: true,
-          arr: [`Key for displaying additional context in options.`],
+          arr: [
+            `<strong>Key for displaying additional context in options.</strong> When provided, shows secondary information from API results alongside the main display text. Useful for disambiguation (e.g., showing region alongside place names).`,
+            `<strong>Dependencies:</strong> Used with <code>source_url</code> to enhance API result presentation with contextual information.`,
+            `<strong>Default:</strong> <code>undefined</code> (no additional context shown)`,
+          ],
         },
       },
 

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -621,7 +621,7 @@
         name: "apiParentResolver",
         category: "Advanced features",
         propType: "fixed",
-        value: function(apiItem) {
+        value: function (apiItem) {
           // Extract parent value from API response
           // Example: return apiItem.codes?.lau2 || apiItem.lau2;
           return apiItem.parentCode;
@@ -646,7 +646,7 @@
         name: "staticChildrenResolver",
         category: "Advanced features",
         propType: "fixed",
-        value: function(staticItem) {
+        value: function (staticItem) {
           // Extract child values from static option
           // Example: return staticItem.children || [];
           return staticItem.postcodes || [];
@@ -671,7 +671,7 @@
         name: "selectedChildParentResolver",
         category: "Advanced features",
         propType: "fixed",
-        value: function(selectedValue) {
+        value: function (selectedValue) {
           // Resolve parent from selected child value
           // Example: Look up postcode's LAD
           return postcodeToLADMapping[selectedValue];
@@ -696,7 +696,8 @@
         name: "tApiChildInSelectedParent",
         category: "Advanced features",
         propType: "fixed",
-        value: (child, parent) => `${child} is in ${parent}, which is already selected`,
+        value: (child, parent) =>
+          `${child} is in ${parent}, which is already selected`,
         functionElements: {
           functionAsString: `function(child, parent) {
   return \`\${child} is in \${parent}, which is already selected\`;
@@ -715,7 +716,8 @@
         name: "tApiChildCoveredBySelectedChild",
         category: "Advanced features",
         propType: "fixed",
-        value: (child, parent, selectedChild) => `${child} is in ${parent}, which is already covered by the selected postcode ${selectedChild}`,
+        value: (child, parent, selectedChild) =>
+          `${child} is in ${parent}, which is already covered by the selected postcode ${selectedChild}`,
         functionElements: {
           functionAsString: `function(child, parent, selectedChild) {
   return \`\${child} is in \${parent}, which is already covered by the selected postcode \${selectedChild}\`;
@@ -734,7 +736,8 @@
         name: "tStaticParentContainsSelectedChildren",
         category: "Advanced features",
         propType: "fixed",
-        value: (parent, children) => `${parent} contains ${children.join(", ")}, which ${children.length > 1 ? "are" : "is"} already selected`,
+        value: (parent, children) =>
+          `${parent} contains ${children.join(", ")}, which ${children.length > 1 ? "are" : "is"} already selected`,
         functionElements: {
           functionAsString: `function(parent, children) {
   return \`\${parent} contains \${children.join(", ")}, which \${children.length > 1 ? "are" : "is"} already selected\`;
@@ -753,7 +756,8 @@
         name: "tPartialPostcodeInSelectedParent",
         category: "Advanced features",
         propType: "fixed",
-        value: (partialPostcode, parent) => `Postcodes beginning ${partialPostcode}... are in ${parent}, which is already selected`,
+        value: (partialPostcode, parent) =>
+          `Postcodes beginning ${partialPostcode}... are in ${parent}, which is already selected`,
         functionElements: {
           functionAsString: `function(partialPostcode, parent) {
   return \`Postcodes beginning \${partialPostcode}... are in \${parent}, which is already selected\`;

--- a/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/MultiSelectSearchAutocompleteWrapper.svelte
@@ -310,7 +310,22 @@
       {
         name: "validate",
         category: "Error handling",
-        value: undefined,
+        value: (value) => {
+          // Default validation: require at least one selection
+          if (!value || (Array.isArray(value) && value.length === 0)) {
+            return "Please select at least one option";
+          }
+          return undefined;
+        },
+        functionElements: {
+          functionAsString: `function(value) {
+  // Default validation: require at least one selection
+  if (!value || (Array.isArray(value) && value.length === 0)) {
+    return "Please select at least one option";
+  }
+  return undefined;
+}`,
+        },
         description: {
           markdown: true,
           arr: [

--- a/src/wrappers/components/ui/SelectWrapper.svelte
+++ b/src/wrappers/components/ui/SelectWrapper.svelte
@@ -215,6 +215,21 @@
         },
       },
       {
+        name: "groups",
+        category: "Core attributes",
+        isEditable: true,
+        value: [],
+        description: {
+          markdown: true,
+          arr: [
+            `An array of objects defining option groups. Each group object should have:`,
+            `<code>label</code>: The label for the option group.`,
+            `<code>choices</code>: An array of options in the same format as the <code>items</code> prop.`,
+            `<code>disabled</code> (optional): Set to <code>true</code> to disable all options in the group.`,
+          ],
+        },
+      },
+      {
         name: "value",
         category: "Core attributes",
         isBinded: true,
@@ -330,6 +345,17 @@
           markdown: true,
           arr: [
             `Optional override for the <code>aria-describedby</code> attribute. If not provided, it's automatically generated based on the presence of hint and error messages.`,
+          ],
+        },
+      },
+      {
+        name: "disabled",
+        category: "Styling and layout",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, disables the select element, preventing user interaction.`,
           ],
         },
       },

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -1079,7 +1079,7 @@
       tPartialPostcodeInSelectedParent={tLsoaPartialPostcodeInSelectedParent}
       bind:value={lsoaSelections11}
       enableSelectedItemCircles={true}
-      selectedItemCircleColorPalette={selectedItemCircleColorPalette}
+      {selectedItemCircleColorPalette}
       matchBorderToCircleColor={true}
       selectedChipBackgroundColor="#FFF"
       choicesItemBorderRadius="5px"

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -1078,6 +1078,11 @@
       tStaticParentContainsSelectedChildren={tLsoaStaticParentContainsSelectedChildren}
       tPartialPostcodeInSelectedParent={tLsoaPartialPostcodeInSelectedParent}
       bind:value={lsoaSelections11}
+      enableSelectedItemCircles={true}
+      selectedItemCircleColorPalette={selectedItemCircleColorPalette}
+      matchBorderToCircleColor={true}
+      selectedChipBackgroundColor="#FFF"
+      choicesItemBorderRadius="5px"
     />
     <p class="govuk-body">
       Selected: {lsoaSelections11.length > 0

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -79,7 +79,116 @@
       heading: "8. Submit Button Functionality",
       content: Example8,
     },
+    {
+      id: "9",
+      heading: "9. LAD ↔ Postcode cross-selection messages",
+      content: Example9,
+    },
   ];
+
+  // Example 9 demo data and resolvers (top-level so snippets can reference them)
+  // Demo LAD options (static)
+  const ladOptions = [
+    { value: "E09000018", text: "London Borough of Hounslow" },
+    { value: "E09000033", text: "City of Westminster" },
+    { value: "E08000003", text: "Manchester" },
+    { value: "E07000173", text: "Mansfield" },
+  ];
+
+  // Tiny demo lookup from specific postcodes to LAD codes
+  // In a real app this would come from your own data service
+  const postcodeToLadDemo = {
+    "TW5 0AA": "E09000018",
+    "TW3 1LR": "E09000018",
+    "SW1A 1AA": "E09000033",
+    "M1 1AE": "E08000003",
+  };
+
+  // Cache resolved LAD codes per postcode to avoid repeated lookups
+  const ladByPostcodeCache = new Map();
+
+  /** Map a postcodes.io entry to its parent LAD (postcodes.io uses `codes.lau2`) */
+  const apiParentResolver = (entry) => {
+    if (!entry) return null;
+    const code = entry?.codes?.lau2; // e.g. E09000018
+    const label = entry?.admin_district ?? undefined; // e.g. Hounslow
+    if (!code) return null;
+    return { value: code, label };
+  };
+
+  /** Given a LAD code, return selected postcode strings that belong to it */
+  const staticChildrenResolver = async (ladCode, selectedValues) => {
+    const all = (selectedValues || []).map((v) => String(v));
+    const pcs = all.filter((s) =>
+      /[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9][A-Z]{2}/i.test(s),
+    );
+
+    const found = [];
+    const toFetch = [];
+
+    for (const pcRaw of pcs) {
+      const pc = pcRaw.toUpperCase();
+      const cached = ladByPostcodeCache.get(pc) || postcodeToLadDemo[pc];
+      if (cached) {
+        ladByPostcodeCache.set(pc, cached);
+        if (cached === ladCode) found.push(pcRaw);
+      } else {
+        toFetch.push(pc);
+      }
+    }
+
+    if (toFetch.length > 0) {
+      try {
+        const res = await fetch("https://api.postcodes.io/postcodes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ postcodes: toFetch }),
+        });
+        const json = await res.json();
+        const results = Array.isArray(json?.result) ? json.result : [];
+        for (const r of results) {
+          const pc = (r?.query || "").toUpperCase();
+          const code = r?.result?.codes?.lau2 || r?.result?.codes?.lad;
+          if (pc && code) {
+            ladByPostcodeCache.set(pc, code);
+            if (code === ladCode) {
+              // find original casing from pcs
+              const original = pcs.find((p) => p.toUpperCase() === pc) ?? pc;
+              found.push(original);
+            }
+          }
+        }
+      } catch (e) {
+        // ignore lookup errors in demo
+      }
+    }
+
+    return found;
+  };
+
+  const tApiChildInSelectedParent = (child, parent) =>
+    `${child} is in ${parent}, which is already selected`;
+
+  const selectedChildParentResolver = (selectedValue) => {
+    // For demo: selectedValue is a postcode string — look up its LAD via cache/map
+    const pc = String(selectedValue).toUpperCase();
+    const code = ladByPostcodeCache.get(pc) || postcodeToLadDemo[pc];
+    if (!code) return null;
+    // We only have a few labels; map known codes to labels
+    const labelMap = {
+      E09000018: "London Borough of Hounslow",
+      E09000033: "City of Westminster",
+      E08000003: "Manchester",
+    };
+    return { value: code, label: labelMap[code] };
+  };
+
+  const tApiChildCoveredBySelectedChild = (child, parent, selectedChild) =>
+    `${child} is in ${parent}, which is already covered by the selected postcode ${selectedChild}`;
+  const tStaticParentContainsSelectedChildren = (parent, children) =>
+    `${parent} contains ${children.join(", ")}, which ${
+      children.length > 1 ? "are" : "is"
+    } already selected`;
 </script>
 
 <div>
@@ -656,4 +765,66 @@
     </div>
   </div>
   <CodeBlock code={codeBlocks.codeBlock8} language="svelte"></CodeBlock>
+{/snippet}
+
+<!-- Example 9: LAD static options with Postcodes API and cross-selection resolvers -->
+{#snippet Example9()}
+  <div class="p-5 bg-white space-y-6">
+    <div>
+      <h6 class="govuk-heading-s">LAD ↔ Postcode cross-selection demo</h6>
+      <p class="govuk-body">
+        Static options are LADs; API suggestions are postcodes from
+        postcodes.io. If you type a postcode within an already-selected LAD, the
+        list will show a dynamic message instead of suggestions. Likewise, if
+        you type a LAD name that contains already-selected postcodes, a message
+        explains which ones are already selected.
+      </p>
+    </div>
+
+    <MultiSelectSearchAutocomplete
+      id="lad-postcode-cross"
+      name="lad-postcode-cross"
+      label="Search LADs (static) and postcodes (API)"
+      hint="Try selecting an LAD (e.g. Hounslow) then type a postcode like TW5 0AA"
+      items={ladOptions}
+      multiple={true}
+      source_url="https://api.postcodes.io/postcodes/"
+      source_key="result"
+      source_property="postcode"
+      minLength={3}
+      groupKey={undefined}
+      sourceSelector={(query) => {
+        const q = query.toUpperCase().trim();
+        if (q.length < 3) return "options"; // mirror Example 5 gating
+
+        // Consider partial postcodes as postcode-like (similar to Example 7)
+        const full = [
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9][A-Z]{2}$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?[0-9][A-Z]{2}$/,
+        ];
+        const partial = [
+          /^[A-Z]{1,2}$/,
+          /^[A-Z]{1,2}[0-9]$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?\s*$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9]$/,
+        ];
+        const looksPc =
+          full.some((p) => p.test(q)) ||
+          partial.some((p) => p.test(q)) ||
+          /\d/.test(q); // heuristic: contains a digit
+
+        return looksPc ? "api" : "options";
+      }}
+      resetApiSuggestionsAfterSelection={true}
+      {apiParentResolver}
+      {staticChildrenResolver}
+      {selectedChildParentResolver}
+      {tApiChildInSelectedParent}
+      {tApiChildCoveredBySelectedChild}
+      {tStaticParentContainsSelectedChildren}
+    />
+  </div>
+
+  <CodeBlock code={codeBlocks.codeBlock9} language="svelte"></CodeBlock>
 {/snippet}

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -100,13 +100,12 @@
     { value: "E07000173", text: "Mansfield" },
   ];
 
-  // Tiny demo lookup from specific postcodes to LAD codes
-  // In a real app this would come from your own data service
+  // Fallback lookup table for postcodes.io API logic
   const postcodeToLadDemo = {
-    "TW5 0AA": "E09000018",
-    "TW3 1LR": "E09000018",
-    "SW1A 1AA": "E09000033",
-    "M1 1AE": "E08000003",
+    "TW5 0AA": "E09000018", // Hounslow postcode → London Borough of Hounslow
+    "TW3 1LR": "E09000018", // Another Hounslow postcode
+    "SW1A 1AA": "E09000033", // Westminster postcode → City of Westminster
+    "M1 1AE": "E08000003", // Manchester postcode → Manchester
   };
 
   // Cache resolved LAD codes per postcode to avoid repeated lookups
@@ -179,7 +178,7 @@
     const pc = String(selectedValue).toUpperCase();
     const code = ladByPostcodeCache.get(pc) || postcodeToLadDemo[pc];
     if (!code) return null;
-    // We only have a few labels; map known codes to labels
+    // Map LAD codes to human-readable labels for demo resolver functions
     const labelMap = {
       E09000018: "London Borough of Hounslow",
       E09000033: "City of Westminster",

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -9,12 +9,12 @@
   import { SvelteMap } from "svelte/reactivity";
 
   // State variables for two-way binding example
-  let globalColorMap = new SvelteMap();
-  let globalNextIndex = 0;
-  let globalSelectedValues = []; // Shared selected values between components
+  let globalColorMap = $state(new SvelteMap());
+  let globalNextIndex = $state(0);
+  let globalSelectedValues = $state([]); // Shared selected values between components
 
   // State variable for submit button demo
-  let selectedValuesForSubmit = [];
+  let selectedValuesForSubmit = $state([]);
 
   // GOV.UK color palette for the example
   const selectedItemCircleColorPalette = [
@@ -83,6 +83,11 @@
       id: "9",
       heading: "9. LAD ↔ Postcode cross-selection messages",
       content: Example9,
+    },
+    {
+      id: "10",
+      heading: "10. Promote postcode selection to parent LAD (with context)",
+      content: Example10,
     },
   ];
 
@@ -189,6 +194,20 @@
     `${parent} contains ${children.join(", ")}, which ${
       children.length > 1 ? "are" : "is"
     } already selected`;
+
+  // Example 10: simple state for promotion demo
+  let ladSelections10 = $state([]);
+
+  // Debug Example 10 state changes
+  $effect(() => {
+    console.log("📋 Example 10 ladSelections10 changed:", {
+      value: ladSelections10,
+      length: ladSelections10?.length,
+      type: typeof ladSelections10,
+      isArray: Array.isArray(ladSelections10),
+      stringified: JSON.stringify(ladSelections10),
+    });
+  });
 </script>
 
 <div>
@@ -827,4 +846,53 @@
   </div>
 
   <CodeBlock code={codeBlocks.codeBlock9} language="svelte"></CodeBlock>
+{/snippet}
+
+<!-- Example 10: Promote postcode to LAD selection with context -->
+{#snippet Example10()}
+  <div class="p-5 bg-white space-y-6">
+    <div>
+      <h6 class="govuk-heading-s">Promote postcode to LAD selection</h6>
+      <p class="govuk-body">
+        Selecting a postcode will instead select its parent LAD. The chip shows
+        contextual text with the originating postcode.
+      </p>
+    </div>
+
+    <MultiSelectSearchAutocomplete
+      id="promote-postcode-to-lad"
+      name="promote-postcode-to-lad"
+      label="Find your local authority"
+      hint="Type a postcode; selecting it will select the parent LAD"
+      items={ladOptions}
+      multiple={true}
+      bind:value={ladSelections10}
+      source_url="https://api.postcodes.io/postcodes/"
+      source_key="result"
+      source_property="postcode"
+      minLength={3}
+      resetApiSuggestionsAfterSelection={true}
+      promoteApiChildToParent={true}
+      groupKey="context"
+      sourceSelector={(query) => {
+        const q = query.toUpperCase().trim();
+        if (q.length < 3) return "options";
+        const looksPc = /\d/.test(q);
+        return looksPc ? "api" : "options";
+      }}
+      {apiParentResolver}
+      {staticChildrenResolver}
+      {selectedChildParentResolver}
+      {tApiChildInSelectedParent}
+      {tApiChildCoveredBySelectedChild}
+      {tStaticParentContainsSelectedChildren}
+    />
+    <p class="govuk-body">
+      Selected: {ladSelections10.length > 0
+        ? ladSelections10.join(", ")
+        : "None selected"}
+    </p>
+  </div>
+
+  <CodeBlock code={codeBlocks.codeBlock10} language="svelte"></CodeBlock>
 {/snippet}

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -195,6 +195,9 @@
       children.length > 1 ? "are" : "is"
     } already selected`;
 
+  const tPartialPostcodeInSelectedParent = (partialPostcode, parent) =>
+    `Postcodes beginning ${partialPostcode}... are in ${parent}, which is already selected`;
+
   // Example 10: simple state for promotion demo
   let ladSelections10 = $state([]);
 
@@ -886,6 +889,7 @@
       {tApiChildInSelectedParent}
       {tApiChildCoveredBySelectedChild}
       {tStaticParentContainsSelectedChildren}
+      {tPartialPostcodeInSelectedParent}
     />
     <p class="govuk-body">
       Selected: {ladSelections10.length > 0

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -1022,13 +1022,13 @@
       <h6 class="govuk-heading-s">Postcode to LSOA promotion demo</h6>
       <p class="govuk-body">
         This example shows how postcodes can be promoted to their parent LSOA
-        (Lower Layer Super Output Area). Static options are LSOAs; API suggestions are
-        postcodes from postcodes.io. When you select a postcode, it gets promoted to
-        its containing LSOA automatically.
+        (Lower Layer Super Output Area). Static options are LSOAs; API
+        suggestions are postcodes from postcodes.io. When you select a postcode,
+        it gets promoted to its containing LSOA automatically.
       </p>
       <p class="govuk-body">
-        <strong>Try this:</strong> Type "TW5 0AA" (Hounslow postcode) and select it.
-        It will be promoted to "Hounslow 018A" LSOA. Or type "SW1A 1AA" (Westminster)
+        <strong>Try this:</strong> Type "TW5 0AA" (Hounslow postcode) and select
+        it. It will be promoted to "Hounslow 018A" LSOA. Or type "SW1A 1AA" (Westminster)
         to see it promoted to "Westminster 018F" LSOA.
       </p>
     </div>

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/Examples.svelte
@@ -89,6 +89,11 @@
       heading: "10. Promote postcode selection to parent LAD (with context)",
       content: Example10,
     },
+    {
+      id: "11",
+      heading: "11. Promote postcode selection to parent LSOA",
+      content: Example11,
+    },
   ];
 
   // Example 9 demo data and resolvers (top-level so snippets can reference them)
@@ -210,6 +215,116 @@
       stringified: JSON.stringify(ladSelections10),
     });
   });
+
+  // Example 11: LSOA promotion demo data and resolvers
+  // Demo LSOA options (static) - using actual LSOA codes and names
+  const lsoaOptions = [
+    { value: "E01002766", text: "Hounslow 018A" }, // LSOA in London Borough of Hounslow
+    { value: "E01004736", text: "Westminster 018F" }, // LSOA in City of Westminster
+    { value: "E01005212", text: "Manchester 057A" }, // LSOA in Manchester
+    { value: "E01025287", text: "Islington 023B" }, // LSOA in Islington
+  ];
+
+  // Fallback lookup table for postcodes.io API logic (postcode -> LSOA)
+  const postcodeToLsoaDemo = {
+    "TW5 0AA": "E01002766", // Hounslow postcode → Hounslow 018A LSOA
+    "TW3 1LR": "E01002766", // Another Hounslow postcode → Same LSOA
+    "SW1A 1AA": "E01004736", // Westminster postcode → Westminster 018F LSOA
+    "M1 1AE": "E01005212", // Manchester postcode → Manchester 057A LSOA
+    "N1 2AB": "E01025287", // Islington postcode → Islington 023B LSOA
+  };
+
+  // Cache resolved LSOA codes per postcode to avoid repeated lookups
+  const lsoaByPostcodeCache = new Map();
+
+  /** Map a postcodes.io entry to its parent LSOA (postcodes.io uses `codes.lsoa`) */
+  const lsoaApiParentResolver = (entry) => {
+    if (!entry) return null;
+    const code = entry?.codes?.lsoa; // e.g. E01002766
+    const label = entry?.lsoa ?? undefined; // e.g. "Hounslow 018A"
+    if (!code) return null;
+    return { value: code, label };
+  };
+
+  /** Given an LSOA code, return selected postcode strings that belong to it */
+  const lsoaStaticChildrenResolver = async (lsoaCode, selectedValues) => {
+    const all = (selectedValues || []).map((v) => String(v));
+    const pcs = all.filter((s) =>
+      /[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9][A-Z]{2}/i.test(s),
+    );
+
+    const found = [];
+    const toFetch = [];
+
+    for (const pcRaw of pcs) {
+      const pc = pcRaw.toUpperCase();
+      const cached = lsoaByPostcodeCache.get(pc) || postcodeToLsoaDemo[pc];
+      if (cached) {
+        lsoaByPostcodeCache.set(pc, cached);
+        if (cached === lsoaCode) found.push(pcRaw);
+      } else {
+        toFetch.push(pc);
+      }
+    }
+
+    if (toFetch.length > 0) {
+      try {
+        const res = await fetch("https://api.postcodes.io/postcodes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ postcodes: toFetch }),
+        });
+        const json = await res.json();
+        const results = Array.isArray(json?.result) ? json.result : [];
+        for (const r of results) {
+          const pc = (r?.query || "").toUpperCase();
+          const code = r?.result?.codes?.lsoa;
+          if (pc && code) {
+            lsoaByPostcodeCache.set(pc, code);
+            if (code === lsoaCode) {
+              // find original casing from pcs
+              const original = pcs.find((p) => p.toUpperCase() === pc) ?? pc;
+              found.push(original);
+            }
+          }
+        }
+      } catch (e) {
+        // ignore lookup errors in demo
+      }
+    }
+
+    return found;
+  };
+
+  const lsoaSelectedChildParentResolver = (selectedValue) => {
+    // For demo: selectedValue is a postcode string — look up its LSOA via cache/map
+    const pc = String(selectedValue).toUpperCase();
+    const code = lsoaByPostcodeCache.get(pc) || postcodeToLsoaDemo[pc];
+    if (!code) return null;
+    // Map LSOA codes to human-readable labels for demo resolver functions
+    const lsoaLabelMap = {
+      E01002766: "Hounslow 018A",
+      E01004736: "Westminster 018F",
+      E01005212: "Manchester 057A",
+      E01025287: "Islington 023B",
+    };
+    return { value: code, label: lsoaLabelMap[code] };
+  };
+
+  // Template functions for LSOA messaging
+  const tLsoaApiChildInSelectedParent = (child, parent) =>
+    `${child} is in ${parent}, which is already selected`;
+  const tLsoaApiChildCoveredBySelectedChild = (child, parent, selectedChild) =>
+    `${child} is in ${parent}, which is already covered by the selected postcode ${selectedChild}`;
+  const tLsoaStaticParentContainsSelectedChildren = (parent, children) =>
+    `${parent} contains ${children.join(", ")}, which ${
+      children.length > 1 ? "are" : "is"
+    } already selected`;
+  const tLsoaPartialPostcodeInSelectedParent = (partialPostcode, parent) =>
+    `Postcodes beginning ${partialPostcode}... are in ${parent}, which is already selected`;
+
+  // Example 11: simple state for LSOA promotion demo
+  let lsoaSelections11 = $state([]);
 </script>
 
 <div>
@@ -898,4 +1013,78 @@
   </div>
 
   <CodeBlock code={codeBlocks.codeBlock10} language="svelte"></CodeBlock>
+{/snippet}
+
+<!-- Example 11: Promote postcode selection to parent LSOA -->
+{#snippet Example11()}
+  <div class="p-5 bg-white space-y-6">
+    <div>
+      <h6 class="govuk-heading-s">Postcode to LSOA promotion demo</h6>
+      <p class="govuk-body">
+        This example shows how postcodes can be promoted to their parent LSOA
+        (Lower Layer Super Output Area). Static options are LSOAs; API suggestions are
+        postcodes from postcodes.io. When you select a postcode, it gets promoted to
+        its containing LSOA automatically.
+      </p>
+      <p class="govuk-body">
+        <strong>Try this:</strong> Type "TW5 0AA" (Hounslow postcode) and select it.
+        It will be promoted to "Hounslow 018A" LSOA. Or type "SW1A 1AA" (Westminster)
+        to see it promoted to "Westminster 018F" LSOA.
+      </p>
+    </div>
+
+    <MultiSelectSearchAutocomplete
+      id="lsoa-promotion-demo"
+      name="lsoa-promotion"
+      label="Search and select LSOAs or postcodes"
+      hint="Type an LSOA name or postcode - postcodes will be promoted to their parent LSOA"
+      items={lsoaOptions}
+      multiple={true}
+      source_url="https://api.postcodes.io/postcodes/"
+      source_key="result"
+      source_property="postcode"
+      minLength={3}
+      groupKey={undefined}
+      sourceSelector={(query) => {
+        const q = query.toUpperCase().trim();
+        if (q.length < 3) return "options";
+
+        // Postcode detection patterns (same as Example 10)
+        const full = [
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9][A-Z]{2}$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?[0-9][A-Z]{2}$/,
+        ];
+        const partial = [
+          /^[A-Z]{1,2}$/,
+          /^[A-Z]{1,2}[0-9]$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?\s*$/,
+          /^[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9]$/,
+        ];
+        const looksPc =
+          full.some((p) => p.test(q)) ||
+          partial.some((p) => p.test(q)) ||
+          /\d/.test(q); // heuristic: contains a digit
+
+        return looksPc ? "api" : "options";
+      }}
+      resetApiSuggestionsAfterSelection={true}
+      promoteApiChildToParent={true}
+      apiParentResolver={lsoaApiParentResolver}
+      staticChildrenResolver={lsoaStaticChildrenResolver}
+      selectedChildParentResolver={lsoaSelectedChildParentResolver}
+      tApiChildInSelectedParent={tLsoaApiChildInSelectedParent}
+      tApiChildCoveredBySelectedChild={tLsoaApiChildCoveredBySelectedChild}
+      tStaticParentContainsSelectedChildren={tLsoaStaticParentContainsSelectedChildren}
+      tPartialPostcodeInSelectedParent={tLsoaPartialPostcodeInSelectedParent}
+      bind:value={lsoaSelections11}
+    />
+    <p class="govuk-body">
+      Selected: {lsoaSelections11.length > 0
+        ? lsoaSelections11.join(", ")
+        : "None selected"}
+    </p>
+  </div>
+
+  <CodeBlock code={codeBlocks.codeBlock11} language="svelte"></CodeBlock>
 {/snippet}

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
@@ -785,3 +785,161 @@ export const codeBlock10 = `
   {tStaticParentContainsSelectedChildren}
   {tPartialPostcodeInSelectedParent}
 />`;
+
+export const codeBlock11 = `
+<script>
+  import MultiSelectSearchAutocomplete from '$lib/components/ui/MultiSelectSearchAutocomplete.svelte';
+
+  // Demo LSOA options (static) - using actual LSOA codes and names
+  const lsoaOptions = [
+    { value: "E01002766", text: "Hounslow 018A" }, // LSOA in London Borough of Hounslow
+    { value: "E01004736", text: "Westminster 018F" }, // LSOA in City of Westminster
+    { value: "E01005212", text: "Manchester 057A" }, // LSOA in Manchester
+    { value: "E01025287", text: "Islington 023B" }, // LSOA in Islington
+  ];
+
+  let lsoaSelections11 = $state([]);
+
+  // Fallback lookup table for postcodes.io API logic (postcode -> LSOA)
+  const postcodeToLsoaDemo = {
+    \"TW5 0AA\": \"E01002766\", // Hounslow postcode → Hounslow 018A LSOA
+    \"TW3 1LR\": \"E01002766\", // Another Hounslow postcode → Same LSOA
+    \"SW1A 1AA\": \"E01004736\", // Westminster postcode → Westminster 018F LSOA
+    \"M1 1AE\": \"E01005212\", // Manchester postcode → Manchester 057A LSOA
+    \"N1 2AB\": \"E01025287\", // Islington postcode → Islington 023B LSOA
+  };
+
+  // Cache resolved LSOA codes per postcode to avoid repeated lookups
+  const lsoaByPostcodeCache = new Map();
+
+  /** Map a postcodes.io entry to its parent LSOA (postcodes.io uses \`codes.lsoa\`) */
+  const lsoaApiParentResolver = (entry) => {
+    if (!entry) return null;
+    const code = entry?.codes?.lsoa; // e.g. E01002766
+    const label = entry?.lsoa ?? undefined; // e.g. "Hounslow 018A"
+    if (!code) return null;
+    return { value: code, label };
+  };
+
+  /** Given an LSOA code, return selected postcode strings that belong to it */
+  const lsoaStaticChildrenResolver = async (lsoaCode, selectedValues) => {
+    const all = (selectedValues || []).map((v) => String(v));
+    const pcs = all.filter((s) =>
+      /[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9][A-Z]{2}/i.test(s),
+    );
+
+    const found = [];
+    const toFetch = [];
+
+    for (const pcRaw of pcs) {
+      const pc = pcRaw.toUpperCase();
+      const cached = lsoaByPostcodeCache.get(pc) || postcodeToLsoaDemo[pc];
+      if (cached) {
+        lsoaByPostcodeCache.set(pc, cached);
+        if (cached === lsoaCode) found.push(pcRaw);
+      } else {
+        toFetch.push(pc);
+      }
+    }
+
+    if (toFetch.length > 0) {
+      try {
+        const res = await fetch("https://api.postcodes.io/postcodes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ postcodes: toFetch }),
+        });
+        const json = await res.json();
+        const results = Array.isArray(json?.result) ? json.result : [];
+        for (const r of results) {
+          const pc = (r?.query || "").toUpperCase();
+          const code = r?.result?.codes?.lsoa;
+          if (pc && code) {
+            lsoaByPostcodeCache.set(pc, code);
+            if (code === lsoaCode) {
+              // find original casing from pcs
+              const original = pcs.find((p) => p.toUpperCase() === pc) ?? pc;
+              found.push(original);
+            }
+          }
+        }
+      } catch (e) {
+        // ignore lookup errors in demo
+      }
+    }
+
+    return found;
+  };
+
+  const lsoaSelectedChildParentResolver = (selectedValue) => {
+    // For demo: selectedValue is a postcode string — look up its LSOA via cache/map
+    const pc = String(selectedValue).toUpperCase();
+    const code = lsoaByPostcodeCache.get(pc) || postcodeToLsoaDemo[pc];
+    if (!code) return null;
+    // Map LSOA codes to human-readable labels for demo resolver functions
+    const lsoaLabelMap = {
+      E01002766: "Hounslow 018A",
+      E01004736: "Westminster 018F",
+      E01005212: "Manchester 057A",
+      E01025287: "Islington 023B",
+    };
+    return { value: code, label: lsoaLabelMap[code] };
+  };
+
+  // Template functions for LSOA messaging
+  const tLsoaApiChildInSelectedParent = (child, parent) =>
+    \`${"${child}"} is in ${"${parent}"}, which is already selected\`;
+  const tLsoaApiChildCoveredBySelectedChild = (child, parent, selectedChild) =>
+    \`${"${child}"} is in ${"${parent}"}, which is already covered by the selected postcode ${"${selectedChild}"}\`;
+  const tLsoaStaticParentContainsSelectedChildren = (parent, children) =>
+    \`${"${parent}"} contains ${'${children.join(", ")}'}, which ${'${children.length > 1 ? "are" : "is"}'} already selected\`;
+  const tLsoaPartialPostcodeInSelectedParent = (partialPostcode, parent) =>
+    \`Postcodes beginning ${"${partialPostcode}"}... are in ${"${parent}"}, which is already selected\`;
+</script>
+
+<MultiSelectSearchAutocomplete
+  id="lsoa-promotion-demo"
+  name="lsoa-promotion"
+  label="Search and select LSOAs or postcodes"
+  hint="Type an LSOA name or postcode - postcodes will be promoted to their parent LSOA"
+  items={lsoaOptions}
+  multiple={true}
+  source_url="https://api.postcodes.io/postcodes/"
+  source_key="result"
+  source_property="postcode"
+  minLength={3}
+  groupKey={undefined}
+  sourceSelector={(query) => {
+    const q = query.toUpperCase().trim();
+    if (q.length < 3) return "options";
+
+    // Postcode detection patterns (same as Example 10)
+    const full = [
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9][A-Z]{2}$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?[0-9][A-Z]{2}$/,
+    ];
+    const partial = [
+      /^[A-Z]{1,2}$/,
+      /^[A-Z]{1,2}[0-9]$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?\\s*$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9]$/,
+    ];
+    const looksPc =
+      full.some((p) => p.test(q)) ||
+      partial.some((p) => p.test(q)) ||
+      /\\d/.test(q); // heuristic: contains a digit
+
+    return looksPc ? "api" : "options";
+  }}
+  resetApiSuggestionsAfterSelection={true}
+  promoteApiChildToParent={true}
+  apiParentResolver={lsoaApiParentResolver}
+  staticChildrenResolver={lsoaStaticChildrenResolver}
+  selectedChildParentResolver={lsoaSelectedChildParentResolver}
+  tApiChildInSelectedParent={tLsoaApiChildInSelectedParent}
+  tApiChildCoveredBySelectedChild={tLsoaApiChildCoveredBySelectedChild}
+  tStaticParentContainsSelectedChildren={tLsoaStaticParentContainsSelectedChildren}
+  tPartialPostcodeInSelectedParent={tLsoaPartialPostcodeInSelectedParent}
+  bind:value={lsoaSelections11}
+/>`;

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
@@ -16,7 +16,12 @@ export const codeBlock1 = `
     { value: "france", text: "France" },
     { value: "germany", text: "Germany" },
     { value: "spain", text: "Spain" },
-    { value: "italy", text: "Italy" }
+    { value: "italy", text: "I    // Map LAD codes to human-readable labels for demo resolver functions
+    const labelMap = {
+      E09000018: \"London Borough of Hounslow\",
+      E09000033: \"City of Westminster\",
+      E08000003: \"Manchester\",
+    };}
   ]}
   multiple={false}
 />`;
@@ -141,12 +146,13 @@ export const codeBlock4 = `
 export const codeBlock6 = `
 <script>
   import MultiSelectSearchAutocomplete from "$lib/components/ui/MultiSelectSearchAutocomplete.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
   import { SvelteMap } from "svelte/reactivity";
   
   // State variables for two-way binding
-  let globalColorMap = new SvelteMap();
-  let globalNextIndex = 0;
-  let globalSelectedValues = []; // Shared selected values between components
+  let globalColorMap = $state(new SvelteMap());
+  let globalNextIndex = $state(0);
+  let globalSelectedValues = $state([]); // Shared selected values between components
   
   // GOV.UK color palette
   const selectedItemCircleColorPalette = [
@@ -555,13 +561,111 @@ export const codeBlock10 = `
 <script>
   import MultiSelectSearchAutocomplete from '$lib/components/ui/MultiSelectSearchAutocomplete.svelte';
 
-  const ladOptions10 = [
-    { value: 'E09000018', text: 'London Borough of Hounslow' },
-    { value: 'E09000033', text: 'City of Westminster' },
-    { value: 'E08000003', text: 'Manchester' }
+  // Demo LAD options (static)
+  const ladOptions = [
+    { value: "E09000018", text: "London Borough of Hounslow" },
+    { value: "E09000033", text: "City of Westminster" },
+    { value: "E08000003", text: "Manchester" },
+    { value: "E07000173", text: "Mansfield" },
   ];
 
-  let ladSelections10 = [];
+  let ladSelections10 = $state([]);
+
+  // Fallback lookup table for postcodes.io API logic
+  const postcodeToLadDemo = {
+    \"TW5 0AA\": \"E09000018\", // Hounslow postcode → London Borough of Hounslow
+    \"TW3 1LR\": \"E09000018\", // Another Hounslow postcode
+    \"SW1A 1AA\": \"E09000033\", // Westminster postcode → City of Westminster
+    \"M1 1AE\": \"E08000003\", // Manchester postcode → Manchester
+  };  // Cache resolved LAD codes per postcode to avoid repeated lookups
+  const ladByPostcodeCache = new Map();
+
+  /** Map a postcodes.io entry to its parent LAD (postcodes.io uses \`codes.lau2\`) */
+  const apiParentResolver = (entry) => {
+    if (!entry) return null;
+    const code = entry?.codes?.lau2; // e.g. E09000018
+    const label = entry?.admin_district ?? undefined; // e.g. Hounslow
+    if (!code) return null;
+    return { value: code, label };
+  };
+
+  /** Given a LAD code, return selected postcode strings that belong to it */
+  const staticChildrenResolver = async (ladCode, selectedValues) => {
+    const all = (selectedValues || []).map((v) => String(v));
+    const pcs = all.filter((s) =>
+      /[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9][A-Z]{2}/i.test(s),
+    );
+
+    const found = [];
+    const toFetch = [];
+
+    for (const pcRaw of pcs) {
+      const pc = pcRaw.toUpperCase();
+      const cached = ladByPostcodeCache.get(pc) || postcodeToLadDemo[pc];
+      if (cached) {
+        ladByPostcodeCache.set(pc, cached);
+        if (cached === ladCode) found.push(pcRaw);
+      } else {
+        toFetch.push(pc);
+      }
+    }
+
+    if (toFetch.length > 0) {
+      try {
+        const res = await fetch("https://api.postcodes.io/postcodes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ postcodes: toFetch }),
+        });
+        const json = await res.json();
+        const results = Array.isArray(json?.result) ? json.result : [];
+        for (const r of results) {
+          const pc = (r?.query || "").toUpperCase();
+          const code = r?.result?.codes?.lau2 || r?.result?.codes?.lad;
+          if (pc && code) {
+            ladByPostcodeCache.set(pc, code);
+            if (code === ladCode) {
+              // find original casing from pcs
+              const original = pcs.find((p) => p.toUpperCase() === pc) ?? pc;
+              found.push(original);
+            }
+          }
+        }
+      } catch (e) {
+        // ignore lookup errors in demo
+      }
+    }
+
+    return found;
+  };
+
+  const selectedChildParentResolver = (selectedValue) => {
+    // For demo: selectedValue is a postcode string — look up its LAD via cache/map
+    const pc = String(selectedValue).toUpperCase();
+    const code = ladByPostcodeCache.get(pc) || postcodeToLadDemo[pc];
+    if (!code) return null;
+    // We only have a few labels; map known codes to labels
+    const labelMap = {
+      E09000018: "London Borough of Hounslow",
+      E09000033: "City of Westminster",
+      E08000003: "Manchester",
+    };
+    return { value: code, label: labelMap[code] };
+  };
+
+  const tApiChildInSelectedParent = (child, parent) =>
+    \`\${child} is in \${parent}, which is already selected\`;
+
+  const tApiChildCoveredBySelectedChild = (child, parent, selectedChild) =>
+    \`\${child} is in \${parent}, which is already covered by the selected postcode \${selectedChild}\`;
+
+  const tStaticParentContainsSelectedChildren = (parent, children) =>
+    \`\${parent} contains \${children.join(", ")}, which \${
+      children.length > 1 ? "are" : "is"
+    } already selected\`;
+
+  const tPartialPostcodeInSelectedParent = (partialPostcode, parent) =>
+    \`Postcodes beginning \${partialPostcode}... are in \${parent}, which is already selected\`;
 </script>
 
 <MultiSelectSearchAutocomplete
@@ -569,7 +673,7 @@ export const codeBlock10 = `
   name="promote-postcode-to-lad"
   label="Find your local authority"
   hint="Type a postcode; selecting it will select the parent LAD"
-  items={ladOptions10}
+  items={ladOptions}
   multiple={true}
   bind:value={ladSelections10}
   source_url="https://api.postcodes.io/postcodes/"
@@ -577,10 +681,19 @@ export const codeBlock10 = `
   source_property="postcode"
   minLength={3}
   resetApiSuggestionsAfterSelection={true}
+  promoteApiChildToParent={true}
   groupKey="context"
   sourceSelector={(query) => {
     const q = query.toUpperCase().trim();
-    if (q.length < 3) return 'options';
-    return /\d/.test(q) ? 'api' : 'options';
+    if (q.length < 3) return "options";
+    const looksPc = /\\d/.test(q);
+    return looksPc ? "api" : "options";
   }}
+  {apiParentResolver}
+  {staticChildrenResolver}
+  {selectedChildParentResolver}
+  {tApiChildInSelectedParent}
+  {tApiChildCoveredBySelectedChild}
+  {tStaticParentContainsSelectedChildren}
+  {tPartialPostcodeInSelectedParent}
 />`;

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
@@ -500,35 +500,78 @@ export const codeBlock9 = `
   const ladOptions = [
     { value: "E09000018", text: "London Borough of Hounslow" },
     { value: "E09000033", text: "City of Westminster" },
-    { value: "E08000003", text: "Manchester" }
+    { value: "E08000003", text: "Manchester" },
+    { value: "E07000173", text: "Mansfield" },
   ];
 
-  // Tiny demo lookup from specific postcodes to LAD codes
+  // Fallback lookup table for postcodes.io API logic
   const postcodeToLadDemo = {
-    "TW5 0AA": "E09000018",
-    "TW3 1LR": "E09000018",
-    "SW1A 1AA": "E09000033",
-    "M1 1AE": "E08000003"
+    "TW5 0AA": "E09000018", // Hounslow postcode → London Borough of Hounslow
+    "TW3 1LR": "E09000018", // Another Hounslow postcode
+    "SW1A 1AA": "E09000033", // Westminster postcode → City of Westminster
+    "M1 1AE": "E08000003", // Manchester postcode → Manchester
   };
 
-  /** Map a postcodes.io entry to its parent LAD */
+  // Cache resolved LAD codes per postcode to avoid repeated lookups
+  const ladByPostcodeCache = new Map();
+
+  /** Map a postcodes.io entry to its parent LAD (postcodes.io uses \`codes.lau2\`) */
   const apiParentResolver = (entry) => {
     if (!entry) return null;
-    const code = entry?.codes?.lad;
-    const label = entry?.admin_district ?? undefined;
+    const code = entry?.codes?.lau2; // e.g. E09000018
+    const label = entry?.admin_district ?? undefined; // e.g. Hounslow
     if (!code) return null;
     return { value: code, label };
   };
 
   /** Given a LAD code, return selected postcode strings that belong to it */
-  const staticChildrenResolver = (ladCode, selectedValues) => {
-    return (selectedValues || []).filter((v) => {
-      const s = String(v);
-      const looksLikePc = /[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9][A-Z]{2}/i.test(s);
-      if (!looksLikePc) return false;
-      const mapped = postcodeToLadDemo[s.toUpperCase()];
-      return mapped === ladCode;
-    });
+  const staticChildrenResolver = async (ladCode, selectedValues) => {
+    const all = (selectedValues || []).map((v) => String(v));
+    const pcs = all.filter((s) =>
+      /[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9][A-Z]{2}/i.test(s),
+    );
+
+    const found = [];
+    const toFetch = [];
+
+    for (const pcRaw of pcs) {
+      const pc = pcRaw.toUpperCase();
+      const cached = ladByPostcodeCache.get(pc) || postcodeToLadDemo[pc];
+      if (cached) {
+        ladByPostcodeCache.set(pc, cached);
+        if (cached === ladCode) found.push(pcRaw);
+      } else {
+        toFetch.push(pc);
+      }
+    }
+
+    if (toFetch.length > 0) {
+      try {
+        const res = await fetch("https://api.postcodes.io/postcodes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ postcodes: toFetch }),
+        });
+        const json = await res.json();
+        const results = Array.isArray(json?.result) ? json.result : [];
+        for (const r of results) {
+          const pc = (r?.query || "").toUpperCase();
+          const code = r?.result?.codes?.lau2 || r?.result?.codes?.lad;
+          if (pc && code) {
+            ladByPostcodeCache.set(pc, code);
+            if (code === ladCode) {
+              // find original casing from pcs
+              const original = pcs.find((p) => p.toUpperCase() === pc) ?? pc;
+              found.push(original);
+            }
+          }
+        }
+      } catch (e) {
+        // ignore lookup errors in demo
+      }
+    }
+
+    return found;
   };
 
   const tApiChildInSelectedParent = (child, parent) =>
@@ -538,6 +581,24 @@ export const codeBlock9 = `
   const tStaticParentContainsSelectedChildren = (parent, children) =>
     \
 \`${"${parent}"} contains ${'${children.join(", ")}'}, which ${'${children.length > 1 ? "are" : "is"}'} already selected\`;
+
+  const selectedChildParentResolver = (selectedValue) => {
+    // For demo: selectedValue is a postcode string — look up its LAD via cache/map
+    const pc = String(selectedValue).toUpperCase();
+    const code = ladByPostcodeCache.get(pc) || postcodeToLadDemo[pc];
+    if (!code) return null;
+    // Map LAD codes to human-readable labels for demo resolver functions
+    const labelMap = {
+      E09000018: "London Borough of Hounslow",
+      E09000033: "City of Westminster",
+      E08000003: "Manchester",
+    };
+    return { value: code, label: labelMap[code] };
+  };
+
+  const tApiChildCoveredBySelectedChild = (child, parent, selectedChild) =>
+    \
+\`${"${child}"} is in ${"${parent}"}, which is already covered by the selected postcode ${"${selectedChild}"}\`;
 </script>
 
 <MultiSelectSearchAutocomplete
@@ -551,9 +612,36 @@ export const codeBlock9 = `
   source_key="result"
   source_property="postcode"
   minLength={3}
+  groupKey={undefined}
+  sourceSelector={(query) => {
+    const q = query.toUpperCase().trim();
+    if (q.length < 3) return "options"; // mirror Example 5 gating
+
+    // Consider partial postcodes as postcode-like (similar to Example 7)
+    const full = [
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9][A-Z]{2}$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?[0-9][A-Z]{2}$/,
+    ];
+    const partial = [
+      /^[A-Z]{1,2}$/,
+      /^[A-Z]{1,2}[0-9]$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?\\s*$/,
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9]$/,
+    ];
+    const looksPc =
+      full.some((p) => p.test(q)) ||
+      partial.some((p) => p.test(q)) ||
+      /\\d/.test(q); // heuristic: contains a digit
+
+    return looksPc ? "api" : "options";
+  }}
+  resetApiSuggestionsAfterSelection={true}
   {apiParentResolver}
   {staticChildrenResolver}
+  {selectedChildParentResolver}
   {tApiChildInSelectedParent}
+  {tApiChildCoveredBySelectedChild}
   {tStaticParentContainsSelectedChildren}
 />`;
 

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
@@ -527,11 +527,11 @@ export const codeBlock9 = `
 
   const tApiChildInSelectedParent = (child, parent) =>
     \
-\`${'${child}'} is in ${'${parent}'}, which is already selected\`;
+\`${"${child}"} is in ${"${parent}"}, which is already selected\`;
 
   const tStaticParentContainsSelectedChildren = (parent, children) =>
     \
-\`${'${parent}'} contains ${'${children.join(", ")}'}, which ${'${children.length > 1 ? "are" : "is"}'} already selected\`;
+\`${"${parent}"} contains ${'${children.join(", ")}'}, which ${'${children.length > 1 ? "are" : "is"}'} already selected\`;
 </script>
 
 <MultiSelectSearchAutocomplete
@@ -549,4 +549,38 @@ export const codeBlock9 = `
   {staticChildrenResolver}
   {tApiChildInSelectedParent}
   {tStaticParentContainsSelectedChildren}
+/>`;
+
+export const codeBlock10 = `
+<script>
+  import MultiSelectSearchAutocomplete from '$lib/components/ui/MultiSelectSearchAutocomplete.svelte';
+
+  const ladOptions10 = [
+    { value: 'E09000018', text: 'London Borough of Hounslow' },
+    { value: 'E09000033', text: 'City of Westminster' },
+    { value: 'E08000003', text: 'Manchester' }
+  ];
+
+  let ladSelections10 = [];
+</script>
+
+<MultiSelectSearchAutocomplete
+  id="promote-postcode-to-lad"
+  name="promote-postcode-to-lad"
+  label="Find your local authority"
+  hint="Type a postcode; selecting it will select the parent LAD"
+  items={ladOptions10}
+  multiple={true}
+  bind:value={ladSelections10}
+  source_url="https://api.postcodes.io/postcodes/"
+  source_key="result"
+  source_property="postcode"
+  minLength={3}
+  resetApiSuggestionsAfterSelection={true}
+  groupKey="context"
+  sourceSelector={(query) => {
+    const q = query.toUpperCase().trim();
+    if (q.length < 3) return 'options';
+    return /\d/.test(q) ? 'api' : 'options';
+  }}
 />`;

--- a/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
+++ b/src/wrappers/components/ui/multi-select-search-autocomplete/codeBlocks.js
@@ -485,3 +485,68 @@ export const codeBlock8 = `
     </div>
   </div>
 </div>`;
+
+export const codeBlock9 = `
+<script>
+  import MultiSelectSearchAutocomplete from "$lib/components/ui/MultiSelectSearchAutocomplete.svelte";
+
+  // Demo LAD options (static)
+  const ladOptions = [
+    { value: "E09000018", text: "London Borough of Hounslow" },
+    { value: "E09000033", text: "City of Westminster" },
+    { value: "E08000003", text: "Manchester" }
+  ];
+
+  // Tiny demo lookup from specific postcodes to LAD codes
+  const postcodeToLadDemo = {
+    "TW5 0AA": "E09000018",
+    "TW3 1LR": "E09000018",
+    "SW1A 1AA": "E09000033",
+    "M1 1AE": "E08000003"
+  };
+
+  /** Map a postcodes.io entry to its parent LAD */
+  const apiParentResolver = (entry) => {
+    if (!entry) return null;
+    const code = entry?.codes?.lad;
+    const label = entry?.admin_district ?? undefined;
+    if (!code) return null;
+    return { value: code, label };
+  };
+
+  /** Given a LAD code, return selected postcode strings that belong to it */
+  const staticChildrenResolver = (ladCode, selectedValues) => {
+    return (selectedValues || []).filter((v) => {
+      const s = String(v);
+      const looksLikePc = /[A-Z]{1,2}[0-9][A-Z0-9]?\s*[0-9][A-Z]{2}/i.test(s);
+      if (!looksLikePc) return false;
+      const mapped = postcodeToLadDemo[s.toUpperCase()];
+      return mapped === ladCode;
+    });
+  };
+
+  const tApiChildInSelectedParent = (child, parent) =>
+    \
+\`${'${child}'} is in ${'${parent}'}, which is already selected\`;
+
+  const tStaticParentContainsSelectedChildren = (parent, children) =>
+    \
+\`${'${parent}'} contains ${'${children.join(", ")}'}, which ${'${children.length > 1 ? "are" : "is"}'} already selected\`;
+</script>
+
+<MultiSelectSearchAutocomplete
+  id="lad-postcode-cross"
+  name="lad-postcode-cross"
+  label="Search LADs (static) and postcodes (API)"
+  hint="Try selecting an LAD (e.g. Hounslow) then type a postcode like TW5 0AA"
+  items={ladOptions}
+  multiple={true}
+  source_url="https://api.postcodes.io/postcodes/"
+  source_key="result"
+  source_property="postcode"
+  minLength={3}
+  {apiParentResolver}
+  {staticChildrenResolver}
+  {tApiChildInSelectedParent}
+  {tStaticParentContainsSelectedChildren}
+/>`;


### PR DESCRIPTION
# Pull request template - for feature branches

A feature branch should make edits/additions to a single component, or limited collection of closely connected components.

Previous pull request for this component or collection of closely connected components should be detailed in the table below.

### Previous pull requests:

| Branch name | Developed by  | Reviewed by  | Link to PR |
| :---------- | :------------ | :----------- | :---------- |
| feature/multi-select-autocomplete-search-component | Ibrahim Haizel | Andrew Hillman | [N/A] |

For any updated component, the developer should consider whether to update the component's status (its main status tag and tick/cross sub-statuses on the wrapper page). A component's status should be updated when it is ready for a particular type of review. The reviewer will then tailor their review accordingly (e.g. if a component’s sub-statuses is updated to include accessible, the reviewer will then test it against our accessibility checklist).

Definitions of each component status can be found on the library's [component statuses page.](https://communitiesuk.github.io/mhclg_svelte_component_library/get-started/component-statuses)

---

### Updated components:

| Name                           | Folder        | Sub-Folder      | Is new component? | Main status change | Sub-statuses additions |
| :----------------------------- | :------------ | :-------------- | ----------------- | ------------------ | ---------------------- |
| SelectWrapper                  | wrappers      | components/ui   | False             | None               | None                   |
| MultiSelectSearchAutocomplete  | ui            | -               | False             | No change          | Enhanced features      |
| MultiSelectSearchAutocompleteWrapper | wrappers | components/ui   | False             | None               | None                   |

---

### Updated component information:

| Name                           | Description                                                                                                                                                        | Context                                                                                                                                                                          |
| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| SelectWrapper                  | Added support for `groups` and `disabled` props in the documentation/config, describing grouped options and global disabling of the select element.                 | Context remains unchanged. These enhancements aid integration with grouped data and accessibility/UX control for disabling the field.                                             |
| MultiSelectSearchAutocomplete  | **Major Enhancement:** Added sophisticated cross-selection logic preventing redundant selections between static options (LADs/LSOAs) and API suggestions (postcodes). Includes optional postcode-to-parent promotion functionality and comprehensive conflict resolution messaging. **+1009 lines, -227 lines of changes.** | Now supports advanced hierarchical relationships between geographic data sources, preventing overlapping selections with user-friendly messaging. Three new comprehensive examples added (LAD↔Postcode cross-selection, Postcode→LAD promotion, Postcode→LSOA promotion). |

---

### Connected components for checking:

| Component     | Connected component              | Change to interaction                                                                 |
| :------------ | :------------------------------- | :------------------------------------------------------------------------------------ |
| SelectWrapper | MultiSelectSearchAutocompleteWrapper | Ensure grouped options and `disabled` prop pass through as expected.                  |
| Select        | MultiSelectSearchAutocomplete | Enhanced documentation in SelectWrapper (26 line additions).                          |

---

### New dependencies:

| Dependency | Description |
| :--------- | :---------- |
| None       | -           |

---

### Core features added:

| Feature                        | Description |
| :----------------------------- | :---------- |
| Groups prop                    | Added documentation/config for `groups` prop, describing grouped options in select component. |
| Disabled prop                  | Added documentation/config for `disabled` prop to allow disabling the select element. |
| **Cross-selection conflict detection** | Intelligent detection when API suggestions (postcodes) belong to already-selected static options (LADs/LSOAs), with contextual messaging. |
| **Postcode-to-parent promotion** | Optional `promoteApiChildToParent` functionality to automatically promote postcode selections to their parent area (LAD/LSOA). |
| **Advanced resolver functions** | New optional resolver functions (`apiParentResolver`, `staticChildrenResolver`, `selectedChildParentResolver`) for parent-child relationships. |
| **Enhanced styling system** | Added styling properties (`choicesItemBorderRadius`, `selectedChipBackgroundColor`, `matchBorderToCircleColor`). |
| **Dynamic messaging framework** | Message templates for various conflict scenarios: `tApiChildInSelectedParent`, `tApiChildCoveredBySelectedChild`, `tStaticParentContainsSelectedChildren`, `tPartialPostcodeInSelectedParent`. |
| **Improved search functionality** | Reduced default search result limit from 100 → 6, added `showSearchIcon` toggle, improved grouped options support. |
| **Full-width support** | New `computedFormGroupClasses` for responsive layouts. |
| **Bindable color state** | External synchronization via `bindSelectedItemIndexMap` and `bindNextSelectionIndex`. |
| **Comprehensive examples** | Three new advanced examples (#9 LAD↔Postcode, #10 Postcode→LAD, #11 Postcode→LSOA). |
| **Enhanced validation** | Default validation requiring at least one selection in demo scenarios. |

---

### Requested checks:

| Check                          | Description |
| :----------------------------- | :---------- |
| Prop documentation             | Verify that `groups` and `disabled` props are described clearly in config. |
| Integration                    | Confirm new props work as expected with wrapper components. |
| Performance testing with resolver functions | Test impact with large datasets and frequent API calls. |
| Cross-selection logic verification | Confirm conflict detection works across LAD-postcode and LSOA-postcode scenarios (examples 9–11). |
| Postcode promotion functionality | Test `promoteApiChildToParent` thoroughly, ensuring promoted items display correctly. |
| Memory management review       | Look for potential memory leaks with Maps, caching, promotion context storage. |
| Accessibility compliance       | Check new messaging, promotion, and dynamic content for screen reader compatibility. |
| API integration testing        | Verify postcodes.io integration with rate limiting and error handling. |


### Key Implementation Details (MultiSelectSearchAutocomplete)

1. **Cross-Selection Prevention Logic**  
   - Detects when API suggestions (postcodes) belong to already-selected static options (LADs/LSOAs).  
   - Prevents redundant geographic selections with contextual user messaging.  

2. **Postcode Promotion System**  
   - Optional `promoteApiChildToParent` functionality promotes postcode selections to their parent area.  
   - Preserves context in chip display: *"Parent Area (containing Original Postcode)"*.  

3. **Advanced Resolver Architecture**  
   - `apiParentResolver`: Maps API items to parent options  
   - `staticChildrenResolver`: Identifies children of static options  
   - `selectedChildParentResolver`: Resolves parent from selected children  

4. **Enhanced Styling System**  
   - CSS props for better visualisation:  
     - `choicesItemBorderRadius`  
     - `selectedChipBackgroundColor`  
     - `matchBorderToCircleColor`  

5. **Comprehensive Example Suite**  
   - **Example 9:** LAD↔Postcode cross-selection with conflict detection  
   - **Example 10:** Postcode→LAD promotion with contextual display  
   - **Example 11:** Postcode→LSOA promotion with enhanced styling  

6. **Performance Optimisations**  
   - Reduced default `searchResultLimit` from 100 → 6.  
   - Intelligent caching and memory management.  

---

### Additional notes:

- No new dependencies were added.  
- This PR significantly enhances **MultiSelectSearchAutocomplete** with sophisticated geographic data handling, focusing on preventing redundant selections and enabling postcode-to-parent promotion.  
- Also improves **SelectWrapper** documentation/config for grouped options and disabled state.   
- Please pay extra attention to **performance**, **accessibility**, and **API integration behaviour** in review.  

---