### PR TITLE
Checkbox select all btn

### DIFF
--- a/src/lib/components/ui/CheckBox.svelte
+++ b/src/lib/components/ui/CheckBox.svelte
@@ -142,6 +142,7 @@
           buttonType={allSelected ? "warning" : "secondary"}
           textContent={allSelected ? "De-select all" : "Select all"}
           onClickFunction={toggleSelectAll}
+          noPadding={true}
         ></Button>
       {/if}
       {#each options as option, i}

--- a/src/lib/components/ui/CheckBox.svelte
+++ b/src/lib/components/ui/CheckBox.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SvelteComponent, Snippet } from "svelte";
+  import Button from "./Button.svelte";
   import { onMount } from "svelte";
   // Define the CheckboxOption type
   export type CheckboxOption = {
@@ -25,6 +26,7 @@
     options = [],
     validate = undefined,
     selectedValues = $bindable([]),
+    selectAllButton = false,
   } = $props<{
     legend: string;
     hint?: string;
@@ -36,6 +38,7 @@
     options?: CheckboxOption[];
     validate?: (values: string[]) => string | undefined;
     selectedValues?: string[];
+    selectAllButton?: boolean;
   }>();
 
   // Add support detection
@@ -70,6 +73,20 @@
             ),
             option.value,
           ];
+    }
+  }
+
+  let allSelected = $derived(
+    selectedValues.length === options.length && options.length > 0,
+  );
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      selectedValues = [];
+      allSelected = false;
+    } else {
+      selectedValues = options.map((option) => option.value);
+      allSelected = true;
     }
   }
 </script>
@@ -120,6 +137,13 @@
       role="group"
       aria-labelledby="{name}-legend"
     >
+      {#if selectAllButton}
+        <Button
+          buttonType={allSelected ? "warning" : "secondary"}
+          textContent={allSelected ? "De-select all" : "Select all"}
+          onClickFunction={toggleSelectAll}
+        ></Button>
+      {/if}
       {#each options as option, i}
         {#if option.exclusive && i > 0}
           <div

--- a/src/wrappers/components/ui/CheckboxWrapper.svelte
+++ b/src/wrappers/components/ui/CheckboxWrapper.svelte
@@ -267,6 +267,11 @@
         }`,
         },
       },
+      {
+        name: "selectAllButton",
+        category: "UI Options",
+        value: false,
+      },
     ]),
   );
 


### PR DESCRIPTION
I added a select all button to the checkbox prop because it is required for IMD. The design was taken from the ONS checkbox https://service-manual.ons.gov.uk/design-system/components/checkboxes?utm_source=chatgpt.com#select-and-unselect-all-checkboxes

Now the dev has the option to include a select all button above the checkbox options. If selected it assigns the values from the option array to the selectedValues array. 