### PR TITLE
Hotfix form action, prerender compatibility bug

### DIFF
--- a/src/routes/components-update/[slug]/[slug]/+page.server.ts
+++ b/src/routes/components-update/[slug]/[slug]/+page.server.ts
@@ -1,159 +1,159 @@
-import { error, json, fail } from "@sveltejs/kit";
-// import { read } from "$app/server"; // No longer using $app/server for reading file
-import fs from "fs";
-import path from "path";
+// import { error, json, fail } from "@sveltejs/kit";
+// // import { read } from "$app/server"; // No longer using $app/server for reading file
+// import fs from "fs";
+// import path from "path";
 
-// Define types for filtered results (mirroring the client-side definition)
-interface FilteredResult {
-  metric: string;
-  areaCode: string;
-  areaName: string;
-  data: { x: string | number; y: string | number }[];
-}
+// // Define types for filtered results (mirroring the client-side definition)
+// interface FilteredResult {
+//   metric: string;
+//   areaCode: string;
+//   areaName: string;
+//   data: { x: string | number; y: string | number }[];
+// }
 
-interface FlatMetricData {
-  metric: string;
-  areaCode: string;
-  x: string | number;
-  y: string | number;
-}
+// interface FlatMetricData {
+//   metric: string;
+//   areaCode: string;
+//   x: string | number;
+//   y: string | number;
+// }
 
-interface TestData {
-  flatMetricData: FlatMetricData[];
-  areaCodeLookup: Record<string, string>;
-}
+// interface TestData {
+//   flatMetricData: FlatMetricData[];
+//   areaCodeLookup: Record<string, string>;
+// }
 
-/** @satisfies {import('./$types').Actions} */
-export const actions = {
-  default: async ({ request }) => {
-    const formData = await request.formData();
+// /** @satisfies {import('./$types').Actions} */
+// export const actions = {
+//   default: async ({ request }) => {
+//     const formData = await request.formData();
 
-    // Check if it's a search form or a filter form
-    if (formData.has("search")) {
-      // Handle search autocomplete submission
-      const search = formData.get("search")?.toString() || "";
-      return { search };
-    } else {
-      // Handle filter panel submission
-      const metricFilter = formData.get("metric")?.toString() || null;
-      const areasFilter = Array.from(formData.getAll("areas[]")).map((value) =>
-        value.toString(),
-      );
-      const yearFilter = formData.get("year")?.toString() || "all";
+//     // Check if it's a search form or a filter form
+//     if (formData.has("search")) {
+//       // Handle search autocomplete submission
+//       const search = formData.get("search")?.toString() || "";
+//       return { search };
+//     } else {
+//       // Handle filter panel submission
+//       const metricFilter = formData.get("metric")?.toString() || null;
+//       const areasFilter = Array.from(formData.getAll("areas[]")).map((value) =>
+//         value.toString(),
+//       );
+//       const yearFilter = formData.get("year")?.toString() || "all";
 
-      // --- Server-side Data Loading ---
-      let testData: TestData;
-      try {
-        // Construct the absolute path to the file
-        // process.cwd() gives the root of your SvelteKit project
-        const filePath = path.join(
-          process.cwd(),
-          "static",
-          "data",
-          "testData.json",
-        );
-        const fileContent = fs.readFileSync(filePath, "utf-8");
-        testData = JSON.parse(fileContent) as TestData;
-      } catch (e: any) {
-        console.error("Error reading or parsing testData.json:", e.message);
-        return fail(500, {
-          step: "data_loading",
-          message: "Failed to load critical data for filtering.",
-          error: e.message,
-        });
-      }
+//       // --- Server-side Data Loading ---
+//       let testData: TestData;
+//       try {
+//         // Construct the absolute path to the file
+//         // process.cwd() gives the root of your SvelteKit project
+//         const filePath = path.join(
+//           process.cwd(),
+//           "static",
+//           "data",
+//           "testData.json",
+//         );
+//         const fileContent = fs.readFileSync(filePath, "utf-8");
+//         testData = JSON.parse(fileContent) as TestData;
+//       } catch (e: any) {
+//         console.error("Error reading or parsing testData.json:", e.message);
+//         return fail(500, {
+//           step: "data_loading",
+//           message: "Failed to load critical data for filtering.",
+//           error: e.message,
+//         });
+//       }
 
-      // --- Server-side Data Transformation ---
-      let dataInFormatForLineChart;
-      try {
-        const metrics: string[] = Array.from(
-          new Set(testData.flatMetricData.map((d: FlatMetricData) => d.metric)),
-        );
-        const areaCodes: string[] = Array.from(
-          new Set(
-            testData.flatMetricData.map((el: FlatMetricData) => el.areaCode),
-          ),
-        );
+//       // --- Server-side Data Transformation ---
+//       let dataInFormatForLineChart;
+//       try {
+//         const metrics: string[] = Array.from(
+//           new Set(testData.flatMetricData.map((d: FlatMetricData) => d.metric)),
+//         );
+//         const areaCodes: string[] = Array.from(
+//           new Set(
+//             testData.flatMetricData.map((el: FlatMetricData) => el.areaCode),
+//           ),
+//         );
 
-        dataInFormatForLineChart = metrics.map((m) => ({
-          metric: m,
-          lines: areaCodes.map((a) => ({
-            areaCode: a,
-            data: testData.flatMetricData.filter(
-              (el: FlatMetricData) => el.areaCode === a && el.metric === m,
-            ),
-          })),
-        }));
-      } catch (e: any) {
-        console.error("Error transforming data:", e.message);
-        return fail(500, {
-          step: "data_transformation",
-          message: "Failed to process loaded data.",
-          error: e.message,
-        });
-      }
+//         dataInFormatForLineChart = metrics.map((m) => ({
+//           metric: m,
+//           lines: areaCodes.map((a) => ({
+//             areaCode: a,
+//             data: testData.flatMetricData.filter(
+//               (el: FlatMetricData) => el.areaCode === a && el.metric === m,
+//             ),
+//           })),
+//         }));
+//       } catch (e: any) {
+//         console.error("Error transforming data:", e.message);
+//         return fail(500, {
+//           step: "data_transformation",
+//           message: "Failed to process loaded data.",
+//           error: e.message,
+//         });
+//       }
 
-      // --- Server-side Filtering Logic ---
-      let results: FilteredResult[] = [];
-      try {
-        if (dataInFormatForLineChart) {
-          let filteredData = [...dataInFormatForLineChart];
+//       // --- Server-side Filtering Logic ---
+//       let results: FilteredResult[] = [];
+//       try {
+//         if (dataInFormatForLineChart) {
+//           let filteredData = [...dataInFormatForLineChart];
 
-          if (metricFilter && metricFilter !== "all" && metricFilter !== "") {
-            filteredData = filteredData.filter(
-              (item) => item.metric === metricFilter,
-            );
-          }
+//           if (metricFilter && metricFilter !== "all" && metricFilter !== "") {
+//             filteredData = filteredData.filter(
+//               (item) => item.metric === metricFilter,
+//             );
+//           }
 
-          filteredData.forEach((metricGroup) => {
-            const areaLines =
-              areasFilter.length > 0
-                ? metricGroup.lines.filter((line) =>
-                    areasFilter.includes(line.areaCode),
-                  )
-                : metricGroup.lines;
+//           filteredData.forEach((metricGroup) => {
+//             const areaLines =
+//               areasFilter.length > 0
+//                 ? metricGroup.lines.filter((line) =>
+//                     areasFilter.includes(line.areaCode),
+//                   )
+//                 : metricGroup.lines;
 
-            areaLines.forEach((line) => {
-              const yearData =
-                yearFilter === "all" || !yearFilter
-                  ? line.data
-                  : line.data.filter(
-                      (point: { x: string | number }) =>
-                        point.x.toString() === yearFilter,
-                    );
+//             areaLines.forEach((line) => {
+//               const yearData =
+//                 yearFilter === "all" || !yearFilter
+//                   ? line.data
+//                   : line.data.filter(
+//                       (point: { x: string | number }) =>
+//                         point.x.toString() === yearFilter,
+//                     );
 
-              if (yearData.length > 0) {
-                results.push({
-                  metric: metricGroup.metric,
-                  areaCode: line.areaCode,
-                  areaName:
-                    testData.areaCodeLookup?.[line.areaCode as string] ||
-                    line.areaCode,
-                  data: yearData,
-                });
-              }
-            });
-          });
-        }
-      } catch (e: any) {
-        console.error("Error during filtering logic:", e.message);
-        return fail(500, {
-          step: "filtering_logic",
-          message: "An error occurred while filtering data.",
-          error: e.message,
-        });
-      }
+//               if (yearData.length > 0) {
+//                 results.push({
+//                   metric: metricGroup.metric,
+//                   areaCode: line.areaCode,
+//                   areaName:
+//                     testData.areaCodeLookup?.[line.areaCode as string] ||
+//                     line.areaCode,
+//                   data: yearData,
+//                 });
+//               }
+//             });
+//           });
+//         }
+//       } catch (e: any) {
+//         console.error("Error during filtering logic:", e.message);
+//         return fail(500, {
+//           step: "filtering_logic",
+//           message: "An error occurred while filtering data.",
+//           error: e.message,
+//         });
+//       }
 
-      // Return the filter data in the expected format
-      return {
-        filterData: {
-          metric: metricFilter,
-          "areas[]": areasFilter,
-          year: yearFilter,
-          results: results,
-          count: results.length,
-        },
-      };
-    }
-  },
-};
+//       // Return the filter data in the expected format
+//       return {
+//         filterData: {
+//           metric: metricFilter,
+//           "areas[]": areasFilter,
+//           year: yearFilter,
+//           results: results,
+//           count: results.length,
+//         },
+//       };
+//     }
+//   },
+// };

--- a/src/wrappers/components/ui/filter-panel/Examples.svelte
+++ b/src/wrappers/components/ui/filter-panel/Examples.svelte
@@ -63,7 +63,7 @@
       : simpleItems.filter((item) => item.category === category);
   }
 
-  // One filter section 
+  // One filter section
   let oneFilterSection = [
     {
       id: "category",
@@ -405,20 +405,39 @@
       are passed back via the `form` prop.
     </p>
 
-    <form method="POST">
+    <form
+      method="POST"
+      use:enhance={({ formData, cancel }) => {
+        // Cancel server submission - process client-side only for demo
+        cancel();
+
+        // Get filter values
+        const selectedMetric = formData.get("metric")?.toString() || null;
+        const selectedAreas = Array.from(formData.getAll("areas[]")).map(
+          (value) => value.toString(),
+        );
+        const selectedYear = formData.get("year")?.toString() || "all";
+
+        // Process client-side (prevents server submission)
+        const results = filterData(selectedMetric, selectedAreas, selectedYear);
+
+        // Update client state for display
+        clientFilteredResults = results;
+        clientResultsCount = `${results.length} results found`;
+        clientFormSubmitted = true;
+      }}
+    >
       <FilterPanel
         sectionsData={metricsFilterSections}
-        resultsCount={form?.filterData?.count !== undefined
-          ? `${form.filterData.count} results found`
-          : "Select filters"}
+        resultsCount={clientResultsCount}
         filterButtonText="Filter metrics"
-        applyButtonText="Submit to server"
+        applyButtonText="Submit to server (Demo - Client-side)"
         ga4BaseEvent={{ event_name: "filter_data", type: "server_submit" }}
       />
     </form>
 
-    <!-- Display results returned from the server via the form prop -->
-    {#if form?.filterData?.results && form.filterData.results.length > 0}
+    <!-- Display results (now processed client-side for demo) -->
+    {#if clientFormSubmitted && clientFilteredResults.length > 0}
       <div class="mt-8 border-t pt-4">
         <div
           class="govuk-notification-banner govuk-notification-banner--success"
@@ -426,18 +445,16 @@
           aria-labelledby="form-success"
         >
           <h2 class="govuk-notification-banner__title" id="form-success">
-            Form submitted to server
+            Form submitted to server (Demo - Client-side)
           </h2>
           <div class="govuk-notification-banner__content">
             <p>
-              The server processed your request and found {form.filterData
-                .count} results.
+              The form would have been processed by the server and found {clientFilteredResults.length}
+              results.
             </p>
             <p class="mt-2 text-sm italic">
-              Selected Filters: Metric: {form.filterData.metric || "Any"},
-              Areas: {form.filterData["areas[]"]?.length > 0
-                ? form.filterData["areas[]"].join(", ")
-                : "Any"}, Year: {form.filterData.year || "Any"}
+              Note: This is a demo - actual server processing is disabled for
+              prerendering compatibility.
             </p>
           </div>
         </div>
@@ -455,7 +472,7 @@
               </tr>
             </thead>
             <tbody>
-              {#each form.filterData.results.slice(0, 5) as result}
+              {#each clientFilteredResults.slice(0, 5) as result}
                 <tr>
                   <td class="px-4 py-2 border">{result.metric}</td>
                   <td class="px-4 py-2 border">{result.areaName}</td>
@@ -467,10 +484,10 @@
                   >
                 </tr>
               {/each}
-              {#if form.filterData.results.length > 5}
+              {#if clientFilteredResults.length > 5}
                 <tr>
                   <td colspan="4" class="px-4 py-2 border text-center italic">
-                    ...and {form.filterData.results.length - 5} more results
+                    ...and {clientFilteredResults.length - 5} more results
                   </td>
                 </tr>
               {/if}
@@ -478,10 +495,10 @@
           </table>
         </div>
       </div>
-    {:else if form?.filterData?.count === 0 && form?.filterData?.results !== undefined}
+    {:else if clientFormSubmitted}
       <div class="mt-8 border-t pt-4">
         <p class="italic">
-          No results match your filter criteria (processed by server).
+          No results match your filter criteria (demo - processed client-side).
         </p>
       </div>
     {/if}
@@ -504,14 +521,33 @@
       the server's response.
     </p>
 
-    <form method="POST" use:enhance>
+    <form
+      method="POST"
+      use:enhance={({ formData, cancel }) => {
+        // Cancel server submission - process client-side only for demo
+        cancel();
+
+        // Get filter values
+        const selectedMetric = formData.get("metric")?.toString() || null;
+        const selectedAreas = Array.from(formData.getAll("areas[]")).map(
+          (value) => value.toString(),
+        );
+        const selectedYear = formData.get("year")?.toString() || "all";
+
+        // Process client-side (prevents server submission)
+        const results = filterData(selectedMetric, selectedAreas, selectedYear);
+
+        // Update client state for display
+        clientFilteredResults = results;
+        clientResultsCount = `${results.length} results found`;
+        clientFormSubmitted = true;
+      }}
+    >
       <FilterPanel
         sectionsData={metricsFilterSections}
-        resultsCount={form?.filterData?.count !== undefined
-          ? `${form.filterData.count} results found`
-          : "Select filters"}
+        resultsCount={clientResultsCount}
         filterButtonText="Filter metrics"
-        applyButtonText="Submit (Enhanced)"
+        applyButtonText="Submit (Enhanced Demo - Client-side)"
         ga4BaseEvent={{
           event_name: "filter_data",
           type: "server_enhanced_submit",
@@ -519,8 +555,8 @@
       />
     </form>
 
-    <!-- Display results returned from the server via the form prop (updated by use:enhance) -->
-    {#if form?.filterData?.results && form.filterData.results.length > 0}
+    <!-- Display results (now processed client-side for demo) -->
+    {#if clientFormSubmitted && clientFilteredResults.length > 0}
       <div class="mt-8 border-t pt-4">
         <div
           class="govuk-notification-banner govuk-notification-banner--success"
@@ -531,18 +567,16 @@
             class="govuk-notification-banner__title"
             id="form-success-basic-enhance"
           >
-            Form submitted (Enhanced by SvelteKit)
+            Form submitted (Enhanced Demo - Client-side)
           </h2>
           <div class="govuk-notification-banner__content">
             <p>
-              The server processed your request and found {form.filterData
-                .count} results. (Submitted without full page reload.)
+              The form would have been processed by the server and found {clientFilteredResults.length}
+              results. (Would be submitted without full page reload.)
             </p>
             <p class="mt-2 text-sm italic">
-              Selected Filters: Metric: {form.filterData.metric || "Any"},
-              Areas: {form.filterData["areas[]"]?.length > 0
-                ? form.filterData["areas[]"].join(", ")
-                : "Any"}, Year: {form.filterData.year || "Any"}
+              Note: This is a demo - actual server processing is disabled for
+              prerendering compatibility.
             </p>
           </div>
         </div>
@@ -559,7 +593,7 @@
               </tr>
             </thead>
             <tbody>
-              {#each form.filterData.results.slice(0, 5) as result}
+              {#each clientFilteredResults.slice(0, 5) as result}
                 <tr>
                   <td class="px-4 py-2 border">{result.metric}</td>
                   <td class="px-4 py-2 border">{result.areaName}</td>
@@ -571,10 +605,10 @@
                   >
                 </tr>
               {/each}
-              {#if form.filterData.results.length > 5}
+              {#if clientFilteredResults.length > 5}
                 <tr>
                   <td colspan="4" class="px-4 py-2 border text-center italic">
-                    ...and {form.filterData.results.length - 5} more results
+                    ...and {clientFilteredResults.length - 5} more results
                   </td>
                 </tr>
               {/if}
@@ -582,11 +616,11 @@
           </table>
         </div>
       </div>
-    {:else if form?.filterData?.count === 0 && form?.filterData?.results !== undefined}
+    {:else if clientFormSubmitted}
       <div class="mt-8 border-t pt-4">
         <p class="italic">
-          No results match your filter criteria (processed by server with
-          enhancement).
+          No results match your filter criteria (demo - processed client-side
+          with enhancement).
         </p>
       </div>
     {/if}


### PR DESCRIPTION
This pull request updates the filter panel demo example to process filter submissions entirely on the client side, instead of submitting to the server. This change is made to ensure compatibility with prerendering and to improve the demo experience. All server-side logic and types in `+page.server.ts` are commented out, and the Svelte example is updated to use client-side filtering and state management.

Key changes include:

**Migration from server-side to client-side filtering:**

* All server-side code, types, and actions in `src/routes/components-update/[slug]/[slug]/+page.server.ts` are commented out, effectively disabling server-side filtering and processing. ([src/routes/components-update/[slug]/[slug]/+page.server.tsL1-R159](diffhunk://#diff-1d4671cbd1bc5a9709073a258e82f348c82d5ccf49661d1a6bb3d87ba137be8fL1-R159))

**Updates to the filter panel example for client-side processing:**

* The filter form in `Examples.svelte` now uses the `enhance` action to intercept form submissions, cancel the server request, and process the filters entirely on the client using a `filterData` function. State variables are updated to reflect the filtered results and submission status. [[1]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L408-R457) [[2]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L507-R559)
* All references to server-provided data (such as `form.filterData`) are replaced with client-managed state variables (`clientFilteredResults`, `clientResultsCount`, `clientFormSubmitted`). This ensures that the UI updates based on client-side filtering results. [[1]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L458-R475) [[2]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L470-R501) [[3]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L562-R596) [[4]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L574-R623)
* Notification banners and result messages are updated to clarify that filtering is now processed client-side for demo purposes, and that no actual server processing occurs. [[1]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L534-R579) [[2]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L470-R501) [[3]](diffhunk://#diff-368670ad320451c2c35d58e9d2042763ab8c5bb9034b38fa0d372dc0857397b3L574-R623)