### PR TITLE
Feature/add autoselect and auto submit focus to autocomplete search component

### DIFF
--- a/src/lib/components/ui/PostcodeOrAreaSearch.svelte
+++ b/src/lib/components/ui/PostcodeOrAreaSearch.svelte
@@ -60,6 +60,7 @@
     autoselect?: boolean; // Auto-highlight first suggestion
     hideHint?: boolean; // Hide the hint input element when autoselect is true
     prefixMatchOnly?: boolean; // Only show suggestions that start with the query
+    autoFocusSubmitOnSelection?: boolean; // Auto-focus submit button when selection is confirmed
     [key: string]: any; // Allow other props
   };
 
@@ -89,6 +90,7 @@
     autoselect = true,
     hideHint = false,
     prefixMatchOnly = false,
+    autoFocusSubmitOnSelection = false,
     ...restProps
   }: Props = $props();
 
@@ -231,6 +233,7 @@
     autoselect,
     hideHint,
     prefixMatchOnly,
+    autoFocusSubmitOnSelection,
     ...restProps,
   });
 </script>

--- a/src/lib/components/ui/PostcodeOrAreaSearch.svelte
+++ b/src/lib/components/ui/PostcodeOrAreaSearch.svelte
@@ -57,6 +57,9 @@
     homepage?: boolean;
     minLength?: number;
     required?: boolean;
+    autoselect?: boolean; // Auto-highlight first suggestion
+    hideHint?: boolean; // Hide the hint input element when autoselect is true
+    prefixMatchOnly?: boolean; // Only show suggestions that start with the query
     [key: string]: any; // Allow other props
   };
 
@@ -83,6 +86,9 @@
     homepage = false,
     minLength = 2,
     required = false,
+    autoselect = true,
+    hideHint = false,
+    prefixMatchOnly = false,
     ...restProps
   }: Props = $props();
 
@@ -222,6 +228,9 @@
     homepage,
     minLength,
     required,
+    autoselect,
+    hideHint,
+    prefixMatchOnly,
     ...restProps,
   });
 </script>

--- a/src/lib/components/ui/SearchAutocomplete.svelte
+++ b/src/lib/components/ui/SearchAutocomplete.svelte
@@ -51,6 +51,9 @@
     hint?: string; // Add hint prop
     selectedValue?: any; // Bindable selected value, updated on selection
     maxSuggestions?: number; // Maximum number of suggestions to display
+    autoselect?: boolean; // Auto-highlight first suggestion
+    hideHint?: boolean; // Hide the hint input element when autoselect is true
+    prefixMatchOnly?: boolean; // Only show suggestions that start with the query (better for hint behavior)
   };
 
   let {
@@ -85,6 +88,9 @@
     hint = undefined, // Add hint destructuring
     selectedValue = $bindable(), // Bindable prop for selected value
     maxSuggestions = undefined, // Maximum number of suggestions to display
+    autoselect = true, // Default to false as per library default
+    hideHint = false, // Default to false - show hint by default
+    prefixMatchOnly = false, // Default to false - show all matches
     ...restSearchProps // Other props for the base Search component
   }: Props = $props();
 
@@ -254,19 +260,50 @@
           populateResults([]);
           return;
         }
+        
         const lowerQuery = query.toLowerCase();
-        const filtered = options.filter((option) => {
-          const label = typeof option === "string" ? option : option.label;
-          return label.toLowerCase().includes(lowerQuery);
-        });
+        
+        if (prefixMatchOnly) {
+          // Only show suggestions that start with the query
+          const filtered = options.filter((option) => {
+            const label = typeof option === "string" ? option : option.label;
+            return label.toLowerCase().startsWith(lowerQuery);
+          });
+          
+          // Apply maxSuggestions limit if specified
+          const limitedResults =
+            maxSuggestions && maxSuggestions > 0
+              ? filtered.slice(0, maxSuggestions)
+              : filtered;
 
-        // Apply maxSuggestions limit if specified
-        const limitedResults =
-          maxSuggestions && maxSuggestions > 0
-            ? filtered.slice(0, maxSuggestions)
-            : filtered;
+          populateResults(limitedResults);
+        } else {
+          // Split results into two groups: starts-with and contains (existing behavior)
+          const startsWithResults: Suggestion[] = [];
+          const containsResults: Suggestion[] = [];
+          
+          options.forEach((option) => {
+            const label = typeof option === "string" ? option : option.label;
+            const lowerLabel = label.toLowerCase();
+            
+            if (lowerLabel.startsWith(lowerQuery)) {
+              startsWithResults.push(option);
+            } else if (lowerLabel.includes(lowerQuery)) {
+              containsResults.push(option);
+            }
+          });
+          
+          // Combine results: starts-with first (for better hint behavior), then contains
+          const filtered = [...startsWithResults, ...containsResults];
 
-        populateResults(limitedResults);
+          // Apply maxSuggestions limit if specified
+          const limitedResults =
+            maxSuggestions && maxSuggestions > 0
+              ? filtered.slice(0, maxSuggestions)
+              : filtered;
+
+          populateResults(limitedResults);
+        }
       };
 
       // Determine which source to use
@@ -297,6 +334,7 @@
       const dynamicSourceFunction = sourceSelector
         ? (query: string, populateResults: (results: Suggestion[]) => void) => {
             const selectedSource = sourceSelector(query, options || []);
+            
             // Handle invalid returns by falling back to default logic
             if (selectedSource === "api") {
               getResultsFromApi(query, populateResults);
@@ -406,6 +444,8 @@
         inputClasses: searchInput.classList, // Pass original classes directly
         source: finalSourceFunction,
         minLength: minLength,
+        autoselect: autoselect,
+        hintClasses: hideHint ? 'hidden-hint' : '',
         confirmOnBlur: confirmOnBlur,
         showNoOptionsFound: showNoOptionsFound,
         defaultValue: defaultValue,
@@ -430,11 +470,9 @@
       const autocompleteInputElement = containerElement?.querySelector(
         ".gem-c-search-with-autocomplete__input",
       ) as HTMLInputElement | null;
-      // console.log(
-      //   "SearchAutocomplete: Input element queried from DOM:",
-      //   autocompleteInputElement,
-      // ); // Updated log
-
+      
+      // Apply hint visibility classes via hintClasses API
+      
       // Post-initialisation tweaks
       if (autocompleteInputElement) {
         // Post-init: dynamically show a 'too-short' warning when the user types fewer than minLength characters
@@ -537,6 +575,54 @@
   :global {
     .gem-c-search-with-autocomplete__wrapper {
       position: relative;
+    }
+
+    /* Hide hint when requested via hintClasses - must come AFTER the default styling for proper cascade */
+    .gem-c-search-with-autocomplete .gem-c-search-with-autocomplete__hint.hidden-hint {
+      display: none !important;
+      visibility: hidden !important;
+    }
+    
+    /* Default hint styling when visible - ensure smooth overlapping with main input */
+    .gem-c-search-with-autocomplete .gem-c-search-with-autocomplete__hint {
+      /* Use identical positioning and sizing as main input */
+      position: absolute !important;
+      top: 0 !important;
+      left: 0 !important;
+      z-index: 99 !important;
+      
+      /* Visual styling for hint */
+      color: rgba(0, 0, 0, 0.4);
+      background: transparent;
+      pointer-events: none;
+      
+      /* Copy EXACT styling from main input */
+      margin: 0;
+      width: 100%;
+      height: 2.1052631579em;
+      padding: 0.3157894737em;
+      border: 2px solid transparent; /* Transparent instead of visible */
+      border-radius: 0;
+      box-sizing: border-box;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      font-family: "GDS Transport", arial, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      font-weight: 400;
+      font-size: 1.1875rem;
+      line-height: 1.4736842105;
+      
+      /* Text alignment */
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      
+      /* Ensure visibility - but allow hidden-hint to override */
+      display: block;
+      visibility: visible;
+      opacity: 1;
     }
 
     .gem-c-search-with-autocomplete__menu {

--- a/src/lib/components/ui/SearchAutocomplete.svelte
+++ b/src/lib/components/ui/SearchAutocomplete.svelte
@@ -260,16 +260,16 @@
           populateResults([]);
           return;
         }
-        
+
         const lowerQuery = query.toLowerCase();
-        
+
         if (prefixMatchOnly) {
           // Only show suggestions that start with the query
           const filtered = options.filter((option) => {
             const label = typeof option === "string" ? option : option.label;
             return label.toLowerCase().startsWith(lowerQuery);
           });
-          
+
           // Apply maxSuggestions limit if specified
           const limitedResults =
             maxSuggestions && maxSuggestions > 0
@@ -281,18 +281,18 @@
           // Split results into two groups: starts-with and contains (existing behavior)
           const startsWithResults: Suggestion[] = [];
           const containsResults: Suggestion[] = [];
-          
+
           options.forEach((option) => {
             const label = typeof option === "string" ? option : option.label;
             const lowerLabel = label.toLowerCase();
-            
+
             if (lowerLabel.startsWith(lowerQuery)) {
               startsWithResults.push(option);
             } else if (lowerLabel.includes(lowerQuery)) {
               containsResults.push(option);
             }
           });
-          
+
           // Combine results: starts-with first (for better hint behavior), then contains
           const filtered = [...startsWithResults, ...containsResults];
 
@@ -334,7 +334,7 @@
       const dynamicSourceFunction = sourceSelector
         ? (query: string, populateResults: (results: Suggestion[]) => void) => {
             const selectedSource = sourceSelector(query, options || []);
-            
+
             // Handle invalid returns by falling back to default logic
             if (selectedSource === "api") {
               getResultsFromApi(query, populateResults);
@@ -445,7 +445,7 @@
         source: finalSourceFunction,
         minLength: minLength,
         autoselect: autoselect,
-        hintClasses: hideHint ? 'hidden-hint' : '',
+        hintClasses: hideHint ? "hidden-hint" : "",
         confirmOnBlur: confirmOnBlur,
         showNoOptionsFound: showNoOptionsFound,
         defaultValue: defaultValue,
@@ -470,9 +470,9 @@
       const autocompleteInputElement = containerElement?.querySelector(
         ".gem-c-search-with-autocomplete__input",
       ) as HTMLInputElement | null;
-      
+
       // Apply hint visibility classes via hintClasses API
-      
+
       // Post-initialisation tweaks
       if (autocompleteInputElement) {
         // Post-init: dynamically show a 'too-short' warning when the user types fewer than minLength characters
@@ -578,11 +578,12 @@
     }
 
     /* Hide hint when requested via hintClasses - must come AFTER the default styling for proper cascade */
-    .gem-c-search-with-autocomplete .gem-c-search-with-autocomplete__hint.hidden-hint {
+    .gem-c-search-with-autocomplete
+      .gem-c-search-with-autocomplete__hint.hidden-hint {
       display: none !important;
       visibility: hidden !important;
     }
-    
+
     /* Default hint styling when visible - ensure smooth overlapping with main input */
     .gem-c-search-with-autocomplete .gem-c-search-with-autocomplete__hint {
       /* Use identical positioning and sizing as main input */
@@ -590,12 +591,12 @@
       top: 0 !important;
       left: 0 !important;
       z-index: 99 !important;
-      
+
       /* Visual styling for hint */
       color: rgba(0, 0, 0, 0.4);
       background: transparent;
       pointer-events: none;
-      
+
       /* Copy EXACT styling from main input */
       margin: 0;
       width: 100%;
@@ -613,12 +614,12 @@
       font-weight: 400;
       font-size: 1.1875rem;
       line-height: 1.4736842105;
-      
+
       /* Text alignment */
       text-align: left;
       white-space: nowrap;
       overflow: hidden;
-      
+
       /* Ensure visibility - but allow hidden-hint to override */
       display: block;
       visibility: visible;

--- a/src/lib/components/ui/SearchAutocomplete.svelte
+++ b/src/lib/components/ui/SearchAutocomplete.svelte
@@ -54,6 +54,7 @@
     autoselect?: boolean; // Auto-highlight first suggestion
     hideHint?: boolean; // Hide the hint input element when autoselect is true
     prefixMatchOnly?: boolean; // Only show suggestions that start with the query (better for hint behavior)
+    autoFocusSubmitOnSelection?: boolean; // Auto-focus submit button when selection is confirmed
   };
 
   let {
@@ -91,6 +92,7 @@
     autoselect = true, // Default to false as per library default
     hideHint = false, // Default to false - show hint by default
     prefixMatchOnly = false, // Default to false - show all matches
+    autoFocusSubmitOnSelection = false, // Default to false - don't auto-focus by default
     ...restSearchProps // Other props for the base Search component
   }: Props = $props();
 
@@ -102,6 +104,8 @@
   let currentSourceUrl = $state<string | undefined>(undefined);
   let currentSourceKey = $state<string | undefined>(undefined);
   let currentSourceProperty = $state<string | undefined>(undefined);
+
+
 
   // --- Derived Values ---
   const wrapperClasses = $derived(
@@ -404,7 +408,12 @@
       // Define confirm function
       let isSubmitting = false; // Prevent double submit
       const handleConfirm = (confirmedValue: Suggestion | undefined) => {
-        if (confirmedValue === undefined || isSubmitting) return;
+        console.log('handleConfirm called with:', confirmedValue, 'isSubmitting:', isSubmitting); // Debug log
+        
+        if (confirmedValue === undefined) return;
+        
+        // Reset submitting flag at the start of each new confirmation
+        isSubmitting = false;
 
         // Re-assign selectedValue before any form-based guard checks (!form) so bindings still update
         // (e.g. when no <form> exists around the component usage) and search component value is being used clienside without a page reload
@@ -417,23 +426,37 @@
         const inputElement =
           autocompleteInstance?.inputElement as HTMLInputElement;
         const form = containerElement?.closest("form");
+        const submitButton = containerElement?.querySelector('button[type="submit"]') as HTMLButtonElement;
+        
+        console.log('Submit button found:', !!submitButton); // Debug log
 
-        if (!inputElement || !form) return;
-
-        isSubmitting = true;
-        inputElement.value = inputValueTemplate(confirmedValue);
-        inputElement.dataset.autocompleteAccepted = "true"; // Set tracking attribute
-
-        // Submit form
-        if (form.requestSubmit) {
-          form.requestSubmit();
-        } else {
-          form.submit(); // Fallback for older browsers
+        // Always focus the submit button first, regardless of form presence (if feature is enabled)
+        if (autoFocusSubmitOnSelection && submitButton) {
+          console.log('Focusing submit button'); // Debug log
+          // Use requestAnimationFrame to ensure the focus happens after DOM updates
+          requestAnimationFrame(() => {
+            submitButton.focus();
+            console.log('Submit button focused, document.activeElement:', document.activeElement === submitButton);
+          });
         }
-        // Reset flag after a short delay in case submission fails/is prevented
-        setTimeout(() => {
+
+        // Handle form submission separately
+        if (inputElement && form) {
+          isSubmitting = true;
+          inputElement.value = inputValueTemplate(confirmedValue);
+          inputElement.dataset.autocompleteAccepted = "true"; // Set tracking attribute
+
+          // Submit form immediately
+          console.log('Submitting form'); // Debug log
+          if (form.requestSubmit) {
+            form.requestSubmit();
+          } else {
+            form.submit(); // Fallback for older browsers
+          }
+          
+          // Reset flag after submission
           isSubmitting = false;
-        }, 500);
+        }
       };
 
       // Initialise accessible-autocomplete
@@ -484,6 +507,13 @@
         // Listen for input changes on the autocomplete field
         autocompleteInputElement.addEventListener("input", () => {
           const val = autocompleteInputElement.value;
+          
+          // Reset isSubmitting flag when user starts typing again
+          if (isSubmitting) {
+            console.log('User typing, resetting isSubmitting flag');
+            isSubmitting = false;
+          }
+          
           // Remove any existing 'too-short' warning before adding a new one to ensure we don't accumulate multiple warning items.
           suggestionsMenu
             ?.querySelector(
@@ -624,6 +654,15 @@
       display: block;
       visibility: visible;
       opacity: 1;
+    }
+
+    /* Custom focus styles for submit button (when focused after autocomplete selection) */
+    .gem-c-search-with-autocomplete .gem-c-search__submit:focus {
+      background-color: #ffdd00; /* GDS focus yellow */
+      border-color: #0b0c0c; /* GDS text color for contrast */
+      color: #0b0c0c; /* Dark text on yellow background */
+      outline: 3px solid #ffdd00;
+      outline-offset: 0;
     }
 
     .gem-c-search-with-autocomplete__menu {

--- a/src/wrappers/components/ui/PostcodeOrAreaSearchWrapper.svelte
+++ b/src/wrappers/components/ui/PostcodeOrAreaSearchWrapper.svelte
@@ -527,6 +527,23 @@
           ],
         },
       },
+      {
+        name: "autoFocusSubmitOnSelection",
+        category: "Behaviour",
+        type: "boolean",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, automatically focuses the submit button when a postcode or area is confirmed.`,
+            `Provides clear visual feedback with GDS focus styling (yellow background) when a location selection is made.`,
+            `The focus styling automatically disappears when focus moves away from the button.`,
+            `Helps users understand that their location selection has been confirmed and is ready to submit.`,
+            `Uses native browser focus behavior for reliable and accessible interaction.`,
+            `Inherited from the underlying SearchAutocomplete component.`,
+          ],
+        },
+      },
     ]),
   );
 
@@ -672,7 +689,7 @@
       ? "#1d70b8"
       : "#fff"}
   <div class="p-8" style="background-color: {bgColor};">
-    {#key [parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.minLength, parametersObject.essOnly, JSON.stringify(parametersObject.customPlacesData)].join("|")}
+    {#key [parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.minLength, parametersObject.essOnly, JSON.stringify(parametersObject.customPlacesData)].join("|")}))}
       <PostcodeOrAreaSearch {...parametersObject} bind:selectedValue />
     {/key}
   </div>

--- a/src/wrappers/components/ui/PostcodeOrAreaSearchWrapper.svelte
+++ b/src/wrappers/components/ui/PostcodeOrAreaSearchWrapper.svelte
@@ -483,6 +483,50 @@
           arr: [`Adds the <code>required</code> attribute to the input field.`],
         },
       },
+      {
+        name: "autoselect",
+        category: "Behaviour",
+        value: true,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, the first suggestion is automatically highlighted and a hint input element is created to show the remaining text.`,
+            `When enabled, users can press Tab or Right Arrow to accept the highlighted suggestion.`,
+            `<strong>Note:</strong> Hints only appear when the first area name starts with the typed query. Use <code>prefixMatchOnly</code> to ensure consistent hint behavior.`,
+            `Inherited from the underlying SearchAutocomplete component.`,
+          ],
+        },
+      },
+      {
+        name: "hideHint",
+        category: "Behaviour",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, hides the hint input element that shows suggestion text when <code>autoselect</code> is enabled.`,
+            `Only has an effect when <code>autoselect</code> is <code>true</code>.`,
+            `Useful when you want the highlighting behavior of autoselect but prefer not to show the visual hint overlay.`,
+            `<strong>Note:</strong> Hints only work for area names that start with the typed query. Areas containing the query mid-name won't show hints.`,
+            `Inherited from the underlying SearchAutocomplete component.`,
+          ],
+        },
+      },
+      {
+        name: "prefixMatchOnly",
+        category: "Behaviour",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, only shows area names that start with the typed query (prefix matching).`,
+            `When <code>false</code> (default), shows all areas that contain the query anywhere in the name (e.g., "westmin" matches both "Westminster" and "Cities of London and Westminster").`,
+            `Setting this to <code>true</code> ensures consistent hint behavior and can improve search relevance.`,
+            `Recommended when <code>autoselect</code> is enabled and you want predictable hint display for area searches.`,
+            `Inherited from the underlying SearchAutocomplete component.`,
+          ],
+        },
+      },
     ]),
   );
 
@@ -628,7 +672,9 @@
       ? "#1d70b8"
       : "#fff"}
   <div class="p-8" style="background-color: {bgColor};">
-    <PostcodeOrAreaSearch {...parametersObject} bind:selectedValue />
+    {#key [parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.minLength, parametersObject.essOnly, JSON.stringify(parametersObject.customPlacesData)].join("|")}
+      <PostcodeOrAreaSearch {...parametersObject} bind:selectedValue />
+    {/key}
   </div>
 {/snippet}
 

--- a/src/wrappers/components/ui/SearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/SearchAutocompleteWrapper.svelte
@@ -355,6 +355,22 @@
         },
       },
       {
+        name: "autoFocusSubmitOnSelection",
+        category: "Interaction",
+        type: "boolean",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, automatically focuses the submit button when a user confirms an autocomplete suggestion.`,
+            `Provides clear visual feedback with GDS focus styling (yellow background) when a selection is made.`,
+            `The focus styling automatically disappears when focus moves away from the button.`,
+            `Uses native browser focus behavior - no manual state management required.`,
+            `Helps users understand that their selection has been confirmed and is ready to submit.`,
+          ],
+        },
+      },
+      {
         name: "showNoOptionsFound",
         category: "Autocomplete",
         value: true,
@@ -933,7 +949,7 @@
       : "#fff"}
   <div class="p-8" style="background-color: {bgColor};">
     {#if parametersObject.source_url && parametersObject.source_key}
-      {#key [parametersObject.source_url, parametersObject.source_key, parametersObject.minLength, parametersObject.confirmOnBlur, parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.showNoOptionsFound, parametersObject.defaultValue, parametersObject.placeholder, parametersObject.required, JSON.stringify(parametersObject.menuAttributes), parametersObject.menuClasses, JSON.stringify(parametersObject.options)].join("|")}}
+            {#key [parametersObject.source_url, parametersObject.source_key, parametersObject.minLength, parametersObject.confirmOnBlur, parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.showNoOptionsFound, parametersObject.defaultValue, parametersObject.placeholder, parametersObject.required, JSON.stringify(parametersObject.menuAttributes), parametersObject.menuClasses, JSON.stringify(parametersObject.options)].join("|")}
         <SearchAutocomplete {...parametersObject} bind:selectedValue />
       {/key}
     {:else}

--- a/src/wrappers/components/ui/SearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/SearchAutocompleteWrapper.svelte
@@ -313,6 +313,48 @@
         },
       },
       {
+        name: "autoselect",
+        category: "Autocomplete",
+        value: true,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, the first suggestion is automatically highlighted and a hint input element is created to show the remaining text.`,
+            `When enabled, users can press Tab or Right Arrow to accept the highlighted suggestion.`,
+            `<strong>Note:</strong> Hints only appear when the first suggestion starts with the typed query. Use <code>prefixMatchOnly</code> to ensure consistent hint behavior.`,
+            `From <a href="https://github.com/alphagov/accessible-autocomplete?tab=readme-ov-file#options-reference" target="_blank">accessible-autocomplete options</a>.`,
+          ],
+        },
+      },
+      {
+        name: "hideHint",
+        category: "Autocomplete",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, hides the hint input element that shows suggestion text when <code>autoselect</code> is enabled.`,
+            `Only has an effect when <code>autoselect</code> is <code>true</code>.`,
+            `Useful when you want the highlighting behavior of autoselect but prefer not to show the visual hint overlay.`,
+            `<strong>Note:</strong> Hints only work for suggestions that start with the typed query. If suggestions appear that contain the query mid-word, no hint will show for those.`,
+          ],
+        },
+      },
+      {
+        name: "prefixMatchOnly",
+        category: "Autocomplete",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, only shows suggestions that start with the typed query (prefix matching).`,
+            `When <code>false</code> (default), shows all suggestions that contain the query anywhere in the text.`,
+            `Setting this to <code>true</code> ensures consistent hint behavior since hints only work with prefix matches.`,
+            `Recommended when <code>autoselect</code> is enabled and you want predictable hint display.`,
+          ],
+        },
+      },
+      {
         name: "showNoOptionsFound",
         category: "Autocomplete",
         value: true,
@@ -891,7 +933,7 @@
       : "#fff"}
   <div class="p-8" style="background-color: {bgColor};">
     {#if parametersObject.source_url && parametersObject.source_key}
-      {#key [parametersObject.source_url, parametersObject.source_key, parametersObject.minLength, parametersObject.confirmOnBlur, parametersObject.showNoOptionsFound, parametersObject.defaultValue, parametersObject.placeholder, parametersObject.required, JSON.stringify(parametersObject.menuAttributes), parametersObject.menuClasses, JSON.stringify(parametersObject.options)].join("|")}
+      {#key [parametersObject.source_url, parametersObject.source_key, parametersObject.minLength, parametersObject.confirmOnBlur, parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.showNoOptionsFound, parametersObject.defaultValue, parametersObject.placeholder, parametersObject.required, JSON.stringify(parametersObject.menuAttributes), parametersObject.menuClasses, JSON.stringify(parametersObject.options)].join("|")}}
         <SearchAutocomplete {...parametersObject} bind:selectedValue />
       {/key}
     {:else}


### PR DESCRIPTION
This pull request adds several new behavioral options to the `SearchAutocomplete` and `PostcodeOrAreaSearch` Svelte components, enhancing their autocomplete functionality and configurability. The main improvements include support for auto-highlighting suggestions, hint visibility control, prefix-only matching, and submit button focus on selection. Documentation and wrapper components are updated accordingly.

**Autocomplete and Search Behavior Enhancements:**

* Added new props to both `SearchAutocomplete` and `PostcodeOrAreaSearch` components: `autoselect` (auto-highlight first suggestion), `hideHint` (hide hint input), `prefixMatchOnly` (only show suggestions that start with the query), and `autoFocusSubmitOnSelection` (focus submit button on selection). Defaults and prop forwarding are handled for seamless integration. [[1]](diffhunk://#diff-eba98bc1a7e298ebca77b36c64596b16b9f117bc41be0c93aaeda32ec200d989R60-R63) [[2]](diffhunk://#diff-eba98bc1a7e298ebca77b36c64596b16b9f117bc41be0c93aaeda32ec200d989R90-R93) [[3]](diffhunk://#diff-eba98bc1a7e298ebca77b36c64596b16b9f117bc41be0c93aaeda32ec200d989R233-R236) [[4]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR54-R57) [[5]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR92-R95)

* Updated the suggestion filtering logic in `SearchAutocomplete` to support prefix-only matching when `prefixMatchOnly` is true, ensuring hints and autoselect behave predictably. [[1]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR267-R274) [[2]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR284-R310)

* Implemented logic to focus the submit button when a suggestion is confirmed and `autoFocusSubmitOnSelection` is enabled, including visual feedback with GDS focus styling. [[1]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbL369-R416) [[2]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR470-R471)

* Added CSS and logic to control hint visibility and style, supporting the new `hideHint` prop and ensuring accessibility and visual consistency.

**Documentation and Wrapper Updates:**

* Documented the new props in the wrapper components (`PostcodeOrAreaSearchWrapper.svelte`, `SearchAutocompleteWrapper.svelte`), including usage notes and behavioral explanations for each option. [[1]](diffhunk://#diff-a6577433791752e88ca835c0391173c9fa116b0163754eda2be9e5346d4f688eR486-R546) [[2]](diffhunk://#diff-f56b5000dde90cb8725744d53587bd4e16d9ab2338b357afeee9b316ca82669bR315-R372)

* Updated wrapper component rendering logic to include the new behavioral props as part of the key, ensuring correct reactivity and demo behavior in the UI. [[1]](diffhunk://#diff-a6577433791752e88ca835c0391173c9fa116b0163754eda2be9e5346d4f688eR692-R694) [[2]](diffhunk://#diff-f56b5000dde90cb8725744d53587bd4e16d9ab2338b357afeee9b316ca82669bL894-R952)