### PR TITLE
Radios accessibility fixes

### DIFF
--- a/src/lib/components/ui/Button.svelte
+++ b/src/lib/components/ui/Button.svelte
@@ -7,6 +7,7 @@
     componentNameProp = undefined,
     onClickFunction = undefined,
     noPadding = false,
+    ariaExpanded = false,
   } = $props();
 
   let buttonClass = $derived(
@@ -25,7 +26,12 @@
 {#if noPadding}
   {#if buttonType === "moreInfo"}
     <div>
-      <button class="more-info-button" onclick={onClickFunction}>
+      <button
+        aria-label={textContent}
+        aria-expanded={ariaExpanded}
+        class="more-info-button"
+        onclick={onClickFunction}
+      >
         <Icon kind="info" />
       </button>
     </div>
@@ -99,7 +105,18 @@
   {/if}
 {:else}
   <div class="p-4">
-    {#if buttonType === "start"}
+    {#if buttonType === "moreInfo"}
+      <div>
+        <button
+          aria-label={textContent}
+          aria-expanded={ariaExpanded}
+          class="more-info-button"
+          onclick={onClickFunction}
+        >
+          <Icon kind="info" />
+        </button>
+      </div>
+    {:else if buttonType === "start"}
       <a
         href={"#"}
         role="button"

--- a/src/lib/components/ui/Radios.svelte
+++ b/src/lib/components/ui/Radios.svelte
@@ -28,6 +28,7 @@
     inline = false,
     options = [],
     validate = undefined,
+    infoButtons = false,
   } = $props<{
     legend: string;
     hint?: string;
@@ -40,6 +41,7 @@
     options?: RadioOption[];
     validate?: (value: string) => string | undefined;
     selectedValue?: string | null;
+    infoButtons?: boolean;
   }>();
 
   // Add support detection
@@ -172,12 +174,13 @@
             {/if}
           </div>
 
-          {#if option.moreInfo}
+          {#if infoButtons && option.moreInfo}
             <Button
-              textContent="i"
+              textContent={"More information about " + option.label}
               buttonType="moreInfo"
               noPadding={true}
               onClickFunction={() => updateMoreInfoTogglesArray(i)}
+              ariaExpanded={moreInfoTogglesArray[i]}
             ></Button>
           {/if}
         </div>
@@ -202,7 +205,12 @@
           </div>
         {/if}
 
-        {#if moreInfoTogglesArray[i]}
+        {#if infoButtons}
+          {#if moreInfoTogglesArray[i]}
+            <InsetText content={option.moreInfo} renderStringAsHTML={true}
+            ></InsetText>
+          {/if}
+        {:else if option.value === selectedValue && option.moreInfo}
           <InsetText content={option.moreInfo} renderStringAsHTML={true}
           ></InsetText>
         {/if}

--- a/src/wrappers/components/ui/ButtonWrapper.svelte
+++ b/src/wrappers/components/ui/ButtonWrapper.svelte
@@ -190,12 +190,21 @@
           "dark background",
           "disabled",
           "table header",
+          "moreInfo",
         ],
         description: {
           markdown: true,
           arr: [`This is the type of <code>${pageName}</code> you want.`],
         },
         rows: 5,
+      },
+      {
+        name: "ariaExpanded",
+        category: "Input props",
+        value: false,
+        description:
+          "Use this value to keep the aria-expanded state of the moreInfo button in sync with the button clicks - you'll probably want to update this value automatically when the onClickFunction runs.",
+        visible: { name: "buttonType", value: "moreInfo" },
       },
       {
         name: "onClickFunction",

--- a/src/wrappers/components/ui/RadiosWrapper.svelte
+++ b/src/wrappers/components/ui/RadiosWrapper.svelte
@@ -256,6 +256,13 @@
         category: "UI Options",
         value: false,
       },
+      {
+        name: "infoButtons",
+        category: "UI Options",
+        value: false,
+        description:
+          "If the radio option has a moreInfo key, make this information available by clicking a button. If false this information is automatically revealed when the radio is selected. Use with caution - in accessibility testing there were issues with focus order when using the buttons.",
+      },
     ]),
   );
 


### PR DESCRIPTION
[Add aria-expanded states to moreInfo buttons, as well as more descrip…](https://github.com/communitiesuk/mhclg_svelte_component_library/commit/bd5333172edb9c7707fb859ab1f2b24c4925df46) - improves accessibility of the `Radios` component, as well as the `Button` component that it uses.