### PR TITLE
Add 'allowFreeTextSubmission' prop to SearchAutocomplete component to enable submission of free-typed text. 

### DIFF
--- a/src/lib/components/ui/SearchAutocomplete.svelte
+++ b/src/lib/components/ui/SearchAutocomplete.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { clsx } from "clsx";
+  import { on } from "svelte/events";
   import Search from "./Search.svelte"; // Base component
   import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
   import { browser } from "$app/environment";
@@ -55,6 +56,7 @@
     hideHint?: boolean; // Hide the hint input element when autoselect is true
     prefixMatchOnly?: boolean; // Only show suggestions that start with the query (better for hint behavior)
     autoFocusSubmitOnSelection?: boolean; // Auto-focus submit button when selection is confirmed
+    allowFreeTextSubmission?: boolean; // Treat free-typed input as confirmed when submitted (works with or without form)
   };
 
   let {
@@ -93,6 +95,7 @@
     hideHint = false, // Default to false - show hint by default
     prefixMatchOnly = false, // Default to false - show all matches
     autoFocusSubmitOnSelection = false, // Default to false - don't auto-focus by default
+    allowFreeTextSubmission = false, // Default to false - only confirmed suggestions submit
     ...restSearchProps // Other props for the base Search component
   }: Props = $props();
 
@@ -104,8 +107,6 @@
   let currentSourceUrl = $state<string | undefined>(undefined);
   let currentSourceKey = $state<string | undefined>(undefined);
   let currentSourceProperty = $state<string | undefined>(undefined);
-
-
 
   // --- Derived Values ---
   const wrapperClasses = $derived(
@@ -408,55 +409,41 @@
       // Define confirm function
       let isSubmitting = false; // Prevent double submit
       const handleConfirm = (confirmedValue: Suggestion | undefined) => {
-        console.log('handleConfirm called with:', confirmedValue, 'isSubmitting:', isSubmitting); // Debug log
-        
-        if (confirmedValue === undefined) return;
-        
-        // Reset submitting flag at the start of each new confirmation
-        isSubmitting = false;
+        if (confirmedValue === undefined || isSubmitting) return;
 
-        // Re-assign selectedValue before any form-based guard checks (!form) so bindings still update
-        // (e.g. when no <form> exists around the component usage) and search component value is being used clienside without a page reload
+        isSubmitting = true;
+
+        // Update selectedValue
         selectedValue =
           typeof confirmedValue === "string"
             ? confirmedValue
             : confirmedValue.value;
 
-        // Type assertion needed here
+        // Mark as accepted to prevent form submit handler from processing again
         const inputElement =
           autocompleteInstance?.inputElement as HTMLInputElement;
-        const form = containerElement?.closest("form");
-        const submitButton = containerElement?.querySelector('button[type="submit"]') as HTMLButtonElement;
-        
-        console.log('Submit button found:', !!submitButton); // Debug log
-
-        // Always focus the submit button first, regardless of form presence (if feature is enabled)
-        if (autoFocusSubmitOnSelection && submitButton) {
-          console.log('Focusing submit button'); // Debug log
-          // Use requestAnimationFrame to ensure the focus happens after DOM updates
-          requestAnimationFrame(() => {
-            submitButton.focus();
-            console.log('Submit button focused, document.activeElement:', document.activeElement === submitButton);
-          });
-        }
-
-        // Handle form submission separately
-        if (inputElement && form) {
-          isSubmitting = true;
+        if (inputElement) {
           inputElement.value = inputValueTemplate(confirmedValue);
-          inputElement.dataset.autocompleteAccepted = "true"; // Set tracking attribute
-
-          // Submit form immediately
-          console.log('Submitting form'); // Debug log
-          if (form.requestSubmit) {
-            form.requestSubmit();
-          } else {
-            form.submit(); // Fallback for older browsers
-          }
-          
-          // Reset flag after submission
-          isSubmitting = false;
+          inputElement.dataset.autocompleteAccepted = "true";
         }
+
+        // Auto-focus submit button if enabled
+        if (autoFocusSubmitOnSelection) {
+          const submitButton = containerElement?.querySelector(
+            'button[type="submit"]',
+          ) as HTMLButtonElement | null;
+          if (submitButton) {
+            requestAnimationFrame(() => submitButton.focus());
+          }
+        }
+
+        // Submit form if present
+        const form = containerElement?.closest("form");
+        if (form) {
+          form.requestSubmit?.() ?? form.submit();
+        }
+
+        isSubmitting = false;
       };
 
       // Initialise accessible-autocomplete
@@ -505,15 +492,15 @@
             ".gem-c-search-with-autocomplete__menu",
           );
         // Listen for input changes on the autocomplete field
-        autocompleteInputElement.addEventListener("input", () => {
+        on(autocompleteInputElement, "input", () => {
           const val = autocompleteInputElement.value;
-          
+
           // Reset isSubmitting flag when user starts typing again
           if (isSubmitting) {
-            console.log('User typing, resetting isSubmitting flag');
+            console.log("User typing, resetting isSubmitting flag");
             isSubmitting = false;
           }
-          
+
           // Remove any existing 'too-short' warning before adding a new one to ensure we don't accumulate multiple warning items.
           suggestionsMenu
             ?.querySelector(
@@ -544,7 +531,7 @@
         // autocompleteInputElement.classList.add("autocomplete__input"); // Add specific class if needed
 
         // Add Enter key workaround from original JS
-        autocompleteInputElement.addEventListener("keydown", (e) => {
+        on(autocompleteInputElement, "keydown", (e) => {
           if (isSubmitting) return; // Don't interfere if already submitting
           const dropdownVisible =
             autocompleteInputElement.getAttribute("aria-expanded") === "true";
@@ -565,6 +552,44 @@
         //   "Autocomplete input classes AFTER add:",
         //   Array.from(autocompleteInputElement.classList),
         // );
+      }
+
+      // Handle free-text submission when allowFreeTextSubmission is enabled
+      // handleConfirm is only called by the library when selecting from dropdown
+      // We need to catch: (1) form submit events, (2) button clicks outside forms
+      if (allowFreeTextSubmission) {
+        const updateFreeText = () => {
+          if (!autocompleteInputElement) return;
+
+          const wasAccepted =
+            autocompleteInputElement.dataset.autocompleteAccepted === "true";
+          const value = autocompleteInputElement.value?.trim();
+
+          if (value && !wasAccepted) {
+            selectedValue = value;
+          }
+
+          // Reset flag after submission
+          setTimeout(() => {
+            if (autocompleteInputElement) {
+              autocompleteInputElement.dataset.autocompleteAccepted = "false";
+            }
+          }, 100);
+        };
+
+        // Handle form submission
+        const form = containerElement?.closest("form");
+        if (form) {
+          on(form, "submit", updateFreeText);
+        }
+
+        // Handle button clicks (for non-form usage)
+        const submitButton = containerElement?.querySelector(
+          'button[type="submit"]',
+        ) as HTMLButtonElement | null;
+        if (submitButton && !form) {
+          on(submitButton, "click", updateFreeText);
+        }
       }
 
       // IMPORTANT: Remove the original Search.svelte input, as accessible-autocomplete replaces it.

--- a/src/wrappers/components/ui/SearchAutocompleteWrapper.svelte
+++ b/src/wrappers/components/ui/SearchAutocompleteWrapper.svelte
@@ -355,6 +355,23 @@
         },
       },
       {
+        name: "allowFreeTextSubmission",
+        category: "Autocomplete",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `If <code>true</code>, allows users to submit free-typed text that doesn't match any suggestions.`,
+            `Works both inside and outside of <code>&lt;form&gt;</code> elements.`,
+            `When enabled, the <code>selectedValue</code> will be updated with the typed text when:`,
+            `• User types text and clicks the submit button (with or without form)`,
+            `• User types text and presses Enter inside a form (without selecting from dropdown)`,
+            `When <code>false</code> (default), only confirmed selections from the dropdown will update <code>selectedValue</code>.`,
+            `Useful when you want to allow both structured suggestions and free-form search queries.`,
+          ],
+        },
+      },
+      {
         name: "autoFocusSubmitOnSelection",
         category: "Interaction",
         type: "boolean",
@@ -949,7 +966,7 @@
       : "#fff"}
   <div class="p-8" style="background-color: {bgColor};">
     {#if parametersObject.source_url && parametersObject.source_key}
-            {#key [parametersObject.source_url, parametersObject.source_key, parametersObject.minLength, parametersObject.confirmOnBlur, parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.showNoOptionsFound, parametersObject.defaultValue, parametersObject.placeholder, parametersObject.required, JSON.stringify(parametersObject.menuAttributes), parametersObject.menuClasses, JSON.stringify(parametersObject.options)].join("|")}
+      {#key [parametersObject.source_url, parametersObject.source_key, parametersObject.minLength, parametersObject.confirmOnBlur, parametersObject.autoselect, parametersObject.hideHint, parametersObject.prefixMatchOnly, parametersObject.allowFreeTextSubmission, parametersObject.showNoOptionsFound, parametersObject.defaultValue, parametersObject.placeholder, parametersObject.required, JSON.stringify(parametersObject.menuAttributes), parametersObject.menuClasses, JSON.stringify(parametersObject.options)].join("|")}
         <SearchAutocomplete {...parametersObject} bind:selectedValue />
       {/key}
     {:else}


### PR DESCRIPTION
This pull request enhances the `SearchAutocomplete` component by adding support for free-text submission, allowing users to submit queries that don't match any suggestions. It introduces a new prop to control this behavior, updates the event handling logic to accommodate both form and non-form usage, and documents the feature in the wrapper component. The changes also refactor event listeners to use Svelte's event utility for improved code consistency.

### Issue Summary

The issue is that `handleConfirm` is **only called** by the `accessible-autocomplete` library when the user confirms a suggestion from the dropdown.  
It is **not triggered** when the user simply clicks the submit button.

### When `handleConfirm` is called
- User selects a suggestion with mouse or touch  
- User highlights a suggestion and presses **Enter**  
- User presses **Enter** on an autoselected suggestion  

### When `handleConfirm` is NOT called
- User types text manually and clicks the **Submit** button (no dropdown interaction)  
- User types text and submits the form without selecting any suggestion  

### Root Cause

The `accessible-autocomplete` library has **no awareness of form submission** — it only handles its **own dropdown interactions**.  
When the user clicks the submit button with typed text, the browser submits the form directly, **bypassing the autocomplete library** and its `onConfirm` callback.

### Implication

Any logic inside `handleConfirm` (e.g., validation, data transformation, or analytics) will **not run** unless the user interacts with the dropdown suggestions.
**Free-text submission feature:**

### Solution

* Added the `allowFreeTextSubmission` prop to `SearchAutocomplete.svelte`, enabling users to submit free-typed input that doesn't match suggestions. When enabled, the component updates `selectedValue` on form submission or submit button click, even if the dropdown isn't used. [[1]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR59) [[2]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR98) [[3]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbR557-R594)
* Documented the new prop in `SearchAutocompleteWrapper.svelte`, including usage details and behavioral notes for both form and non-form contexts.

**Event handling improvements:**

* Refactored event listeners for `input` and `keydown` events to use Svelte's `on` utility instead of native `addEventListener`, improving code consistency and cleanup. [[1]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbL508-R500) [[2]](diffhunk://#diff-befef424eaa09ad574d89ba912d385b7c454590de79180133c1b19bc3d2f6adbL547-R534)
* Updated the key used for the `{#key ...}` block in `SearchAutocompleteWrapper.svelte` to include the new `allowFreeTextSubmission` prop, ensuring correct reactivity when this prop changes.

**General code quality:**

* Improved the confirmation and submission logic in `SearchAutocomplete.svelte` to prevent double submissions, ensure proper flag resets, and streamline form/button handling.