### PR TITLE
Card improvements

### DIFF
--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -11,7 +11,9 @@
     bodyTopBorderColor = "#F4F8FB",
     bodyBottomBorderColor = "#c3d9e9",
     selectedValue = $bindable(),
-    cardSnippet = undefined,
+    cardTopSnippet = undefined,
+    cardBottomSnippet = undefined,
+    onlyTextInBody = true,
   } = $props();
 </script>
 
@@ -44,7 +46,7 @@
         </a>
       </h2>
     {:else}
-      {@render cardSnippet()}
+      {@render cardTopSnippet()}
     {/if}
   </div>
 
@@ -52,9 +54,16 @@
     class="body-div"
     style="--body-bg-color: {bodyBackgroundColor}; --body-bottom-border-color: {bodyBottomBorderColor}; --body-top-border-color: {bodyTopBorderColor};"
   >
-    <p class="govuk-body body-text" style="--body-text-color: {bodyTextColor};">
-      {bodyText}
-    </p>
+    {#if onlyTextInBody}
+      <p
+        class="govuk-body body-text"
+        style="--body-text-color: {bodyTextColor};"
+      >
+        {bodyText}
+      </p>
+    {:else}
+      {@render cardBottomSnippet()}
+    {/if}
   </div>
 </div>
 

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -3,6 +3,11 @@
 
   let {
     headerIsLink = true,
+    text = "Card header",
+    fontSize = "1.5rem",
+    textColor = "#1D70B8",
+    backgroundColor = "white",
+    href = undefined,
     onlyTextInBody = true,
     bodyText = "Text in the body of the card",
     headerSnippet = undefined,
@@ -20,7 +25,8 @@
 <div class="card">
   <div class="header-div" style="background-color: {headerBackgroundColor};">
     {#if headerIsLink}
-      <CardHeader></CardHeader>
+      <CardHeader {text} {fontSize} {textColor} {backgroundColor} {href}
+      ></CardHeader>
     {:else}
       {@render headerSnippet()}
     {/if}
@@ -59,7 +65,7 @@
     background-color: var(--body-bg-color);
     border-bottom: 1px solid var(--body-bottom-border-color);
     border-top: 1px solid var(--body-top-border-color);
-    padding: 10px 20px 15px 20px;
+    padding: 15px 20px;
     flex: 1;
   }
 

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,15 +1,15 @@
 <script>
   let {
-    headingIsLink = true,
+    headerIsLink = true,
     onlyTextInBody = true,
     linkText = undefined,
     bodyText = undefined,
-    cardTopSnippet = undefined,
-    cardBottomSnippet = undefined,
+    headerSnippet = undefined,
+    bodySnippet = undefined,
     children = undefined,
     linkTextColor = "#1D70B8",
     bodyTextColor = "#0B0C0C",
-    callToActionBackgroundColor = "white",
+    headerBackgroundColor = "white",
     bodyBackgroundColor = "#FBFCFD",
     bodyTopBorderColor = "#F4F8FB",
     bodyBottomBorderColor = "#c3d9e9",
@@ -21,9 +21,9 @@
 <div class="card">
   <div
     class="call-to-action"
-    style="background-color: {callToActionBackgroundColor};"
+    style="background-color: {headerBackgroundColor};"
   >
-    {#if headingIsLink}
+    {#if headerIsLink}
       <h2 class="link-heading govuk-heading-m">
         <a
           class="govuk-link link"
@@ -47,7 +47,7 @@
         </a>
       </h2>
     {:else}
-      {@render cardTopSnippet()}
+      {@render headerSnippet()}
     {/if}
   </div>
 
@@ -65,7 +65,7 @@
     {:else if children}
       {@render children?.()}
     {:else}
-      {@render cardBottomSnippet()}
+      {@render bodySnippet()}
     {/if}
   </div>
 </div>

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -3,10 +3,10 @@
 
   let {
     headerIsLink = true,
-    text = "Card header",
-    fontSize = "1.5rem",
-    textColor = "#1D70B8",
-    backgroundColor = "white",
+    headerText = "Card header",
+    headerTextSize = "1.5rem",
+    headerTextColor = "#1D70B8",
+    headerBackgroundColor = "white",
     href = undefined,
     onlyTextInBody = true,
     bodyText = "Text in the body of the card",
@@ -14,7 +14,6 @@
     bodySnippet = undefined,
     children = undefined,
     bodyTextColor = "#0B0C0C",
-    headerBackgroundColor = "white",
     bodyBackgroundColor = "#FBFCFD",
     bodyTopBorderColor = "#F4F8FB",
     bodyBottomBorderColor = "#c3d9e9",
@@ -25,10 +24,15 @@
 <div class="card">
   <div class="header-div" style="background-color: {headerBackgroundColor};">
     {#if headerIsLink}
-      <CardHeader {text} {fontSize} {textColor} {backgroundColor} {href}
+      <CardHeader
+        text={headerText}
+        textSize={headerTextSize}
+        textColor={headerTextColor}
+        backgroundColor={headerBackgroundColor}
+        {href}
       ></CardHeader>
     {:else}
-      {@render headerSnippet()}
+      {@render headerSnippet?.()}
     {/if}
   </div>
 
@@ -46,7 +50,7 @@
     {:else if children}
       {@render children?.()}
     {:else}
-      {@render bodySnippet()}
+      {@render bodySnippet?.()}
     {/if}
   </div>
 </div>

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -101,7 +101,6 @@
   }
 
   .govuk-heading-m {
-    /* overwriting margin and line-height to make link centered vertically */
     margin: 0;
     line-height: 1;
   }

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,10 +1,10 @@
 <script>
   let {
     headerIsLink = true,
-    headerText = undefined,
+    headerText = "Card heading",
     href = undefined,
     onlyTextInBody = true,
-    bodyText = undefined,
+    bodyText = "Text in the body of the card",
     headerSnippet = undefined,
     bodySnippet = undefined,
     children = undefined,
@@ -25,11 +25,7 @@
   >
     {#if headerIsLink}
       <h2 class="link-heading govuk-heading-m">
-        <a
-          class="govuk-link link"
-          {href}
-          style="--link-text-color: {headerTextColor}"
-        >
+        <a class="govuk-link link" {href} style="color: {headerTextColor}">
           {headerText}
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -85,10 +81,6 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-  }
-
-  .link-heading {
-    color: var(--link-text-color);
   }
 
   .body-div {

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -18,11 +18,17 @@
     bodyTopBorderColor = "#F4F8FB",
     bodyBottomBorderColor = "#c3d9e9",
     selectedValue = $bindable(),
+    display = "flex",
+    gridPosition = undefined,
   } = $props();
 </script>
 
-<div class="card">
-  <div class="header-div" style="background-color: {headerBackgroundColor};">
+<div class="card" style="display: {display}">
+  <div
+    class="header-div"
+    style="background-color: {headerBackgroundColor}; grid-row: {gridPosition?.[0]
+      ?.row ?? null}; grid-column: {gridPosition?.[0]?.col ?? null};"
+  >
     {#if headerIsLink}
       <CardHeader
         text={headerText}
@@ -38,7 +44,8 @@
 
   <div
     class="body-div"
-    style="--body-bg-color: {bodyBackgroundColor}; --body-bottom-border-color: {bodyBottomBorderColor}; --body-top-border-color: {bodyTopBorderColor};"
+    style="--body-bg-color: {bodyBackgroundColor}; --body-bottom-border-color: {bodyBottomBorderColor}; --body-top-border-color: {bodyTopBorderColor}; grid-row: {gridPosition?.[1]
+      ?.row ?? null}; grid-column: {gridPosition?.[1]?.col ?? null};"
   >
     {#if onlyTextInBody}
       <p
@@ -57,7 +64,6 @@
 
 <style>
   .card {
-    display: flex;
     flex-direction: column;
   }
 

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -2,6 +2,7 @@
   let {
     headerIsLink = true,
     headerText = "Card heading",
+    headerSize = "m",
     href = undefined,
     onlyTextInBody = true,
     bodyText = "Text in the body of the card",
@@ -19,12 +20,9 @@
 </script>
 
 <div class="card">
-  <div
-    class="call-to-action"
-    style="background-color: {headerBackgroundColor};"
-  >
+  <div class="header-div" style="background-color: {headerBackgroundColor};">
     {#if headerIsLink}
-      <h2 class="link-heading govuk-heading-m">
+      <h2 class="link-heading govuk-heading-{headerSize}">
         <a class="govuk-link link" {href} style="color: {headerTextColor}">
           {headerText}
           <svg
@@ -72,7 +70,7 @@
     flex-direction: column;
   }
 
-  .call-to-action {
+  .header-div {
     padding: 15px 20px;
   }
 

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,15 +1,13 @@
 <script>
+  import CardHeader from "./CardHeader.svelte";
+
   let {
     headerIsLink = true,
-    headerText = "Card heading",
-    headerSize = "m",
-    href = undefined,
     onlyTextInBody = true,
     bodyText = "Text in the body of the card",
     headerSnippet = undefined,
     bodySnippet = undefined,
     children = undefined,
-    headerTextColor = "#1D70B8",
     bodyTextColor = "#0B0C0C",
     headerBackgroundColor = "white",
     bodyBackgroundColor = "#FBFCFD",
@@ -22,24 +20,7 @@
 <div class="card">
   <div class="header-div" style="background-color: {headerBackgroundColor};">
     {#if headerIsLink}
-      <h2 class="link-heading govuk-heading-{headerSize}">
-        <a class="govuk-link link" {href} style="color: {headerTextColor}">
-          {headerText}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="10"
-            height="17"
-            viewBox="0 0 10 17"
-            fill="none"
-            aria-hidden="true"
-          >
-            <path
-              d="M6.21622 8.5L0 2.36667L1.89189 0.5L10 8.5L1.89189 16.5L0 14.6333L6.21622 8.5Z"
-              fill={headerTextColor}
-            ></path>
-          </svg>
-        </a>
-      </h2>
+      <CardHeader></CardHeader>
     {:else}
       {@render headerSnippet()}
     {/if}
@@ -71,14 +52,7 @@
   }
 
   .header-div {
-    padding: 15px 20px;
-  }
-
-  .link {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
+    padding: 20px;
   }
 
   .body-div {
@@ -91,14 +65,5 @@
 
   .body-text {
     color: var(--body-text-color);
-  }
-
-  .govuk-heading-m {
-    margin: 0;
-    line-height: 1;
-  }
-
-  a {
-    color: #1d70b8;
   }
 </style>

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,19 +1,19 @@
 <script>
   let {
     headerIsLink = true,
+    headerText = undefined,
+    href = undefined,
     onlyTextInBody = true,
-    linkText = undefined,
     bodyText = undefined,
     headerSnippet = undefined,
     bodySnippet = undefined,
     children = undefined,
-    linkTextColor = "#1D70B8",
+    headerTextColor = "#1D70B8",
     bodyTextColor = "#0B0C0C",
     headerBackgroundColor = "white",
     bodyBackgroundColor = "#FBFCFD",
     bodyTopBorderColor = "#F4F8FB",
     bodyBottomBorderColor = "#c3d9e9",
-    href = undefined,
     selectedValue = $bindable(),
   } = $props();
 </script>
@@ -28,9 +28,9 @@
         <a
           class="govuk-link link"
           {href}
-          style="--link-text-color: {linkTextColor}"
+          style="--link-text-color: {headerTextColor}"
         >
-          {linkText}
+          {headerText}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="10"
@@ -41,7 +41,7 @@
           >
             <path
               d="M6.21622 8.5L0 2.36667L1.89189 0.5L10 8.5L1.89189 16.5L0 14.6333L6.21622 8.5Z"
-              fill={linkTextColor}
+              fill={headerTextColor}
             ></path>
           </svg>
         </a>

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,19 +1,19 @@
 <script>
   let {
     linkCard = true,
+    onlyTextInBody = true,
     linkText = undefined,
-    linkTextColor = "#1D70B8",
-    href = undefined,
-    callToActionBackgroundColor = "white",
     bodyText = undefined,
+    cardTopSnippet = undefined,
+    cardBottomSnippet = undefined,
+    linkTextColor = "#1D70B8",
     bodyTextColor = "#0B0C0C",
+    callToActionBackgroundColor = "white",
     bodyBackgroundColor = "#FBFCFD",
     bodyTopBorderColor = "#F4F8FB",
     bodyBottomBorderColor = "#c3d9e9",
+    href = undefined,
     selectedValue = $bindable(),
-    cardTopSnippet = undefined,
-    cardBottomSnippet = undefined,
-    onlyTextInBody = true,
   } = $props();
 </script>
 

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,11 +1,12 @@
 <script>
   let {
-    linkCard = true,
+    headingIsLink = true,
     onlyTextInBody = true,
     linkText = undefined,
     bodyText = undefined,
     cardTopSnippet = undefined,
     cardBottomSnippet = undefined,
+    children = undefined,
     linkTextColor = "#1D70B8",
     bodyTextColor = "#0B0C0C",
     callToActionBackgroundColor = "white",
@@ -22,7 +23,7 @@
     class="call-to-action"
     style="background-color: {callToActionBackgroundColor};"
   >
-    {#if linkCard}
+    {#if headingIsLink}
       <h2 class="link-heading govuk-heading-m">
         <a
           class="govuk-link link"
@@ -61,6 +62,8 @@
       >
         {bodyText}
       </p>
+    {:else if children}
+      {@render children?.()}
     {:else}
       {@render cardBottomSnippet()}
     {/if}

--- a/src/lib/components/ui/CardHeader.svelte
+++ b/src/lib/components/ui/CardHeader.svelte
@@ -4,12 +4,13 @@
     fontSize = "1.5rem",
     textColor = "#1D70B8",
     backgroundColor = "white",
+    href = undefined,
   } = $props();
 </script>
 
 <a
-  class="govuk-heading-m link"
-  href="/"
+  class="link govuk-heading-m"
+  {href}
   style="font-size: {fontSize}; color: {textColor}; background-color: {backgroundColor}"
 >
   {text}
@@ -28,6 +29,10 @@
 </a>
 
 <style>
+  * {
+    margin: 0; /* this removes the margin applied by govuk-heading-m */
+  }
+
   .link {
     display: flex;
     justify-content: space-between;

--- a/src/lib/components/ui/CardHeader.svelte
+++ b/src/lib/components/ui/CardHeader.svelte
@@ -38,5 +38,6 @@
     justify-content: space-between;
     align-items: center;
     width: 100%;
+    gap: 0.5rem;
   }
 </style>

--- a/src/lib/components/ui/CardHeader.svelte
+++ b/src/lib/components/ui/CardHeader.svelte
@@ -1,7 +1,7 @@
 <script>
   let {
     text = "Card header",
-    fontSize = "1.5rem",
+    textSize = "1.5rem",
     textColor = "#1D70B8",
     backgroundColor = "white",
     href = undefined,
@@ -11,7 +11,7 @@
 <a
   class="link govuk-heading-m"
   {href}
-  style="font-size: {fontSize}; color: {textColor}; background-color: {backgroundColor}"
+  style="font-size: {textSize}; color: {textColor}; background-color: {backgroundColor}"
 >
   {text}
   <svg

--- a/src/lib/components/ui/CardHeader.svelte
+++ b/src/lib/components/ui/CardHeader.svelte
@@ -1,0 +1,37 @@
+<script>
+  let {
+    text = "Card header",
+    fontSize = "1.5rem",
+    textColor = "#1D70B8",
+    backgroundColor = "white",
+  } = $props();
+</script>
+
+<a
+  class="govuk-heading-m link"
+  href="/"
+  style="font-size: {fontSize}; color: {textColor}; background-color: {backgroundColor}"
+>
+  {text}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 10 17"
+    aria-hidden="true"
+  >
+    <path
+      d="M6.21622 8.5L0 2.36667L1.89189 0.5L10 8.5L1.89189 16.5L0 14.6333L6.21622 8.5Z"
+      fill="currentColor"
+    ></path>
+  </svg>
+</a>
+
+<style>
+  .link {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+</style>

--- a/src/wrappers/components/ui/CardHeader/CardHeaderWrapper.svelte
+++ b/src/wrappers/components/ui/CardHeader/CardHeaderWrapper.svelte
@@ -1,0 +1,486 @@
+<script module>
+  import BaseNameAndStatus from "$lib/package-wrapping/BaseNameAndStatus.svelte";
+  import BaseInformation from "$lib/package-wrapping/BaseInformation.svelte";
+  export { WrapperNameAndStatus, WrapperInformation };
+
+  /**
+   * !  More documentation is provided on the component library's user guide page.
+   */
+
+  /**
+   * ! STEP 1 - Adding component metadata
+   * CUSTOMISETHIS  Update the status for this component.
+   * && 	statusObject.progress determines which pill is shown against the component's name.
+   * ?  progress must be one of:
+   * ?  1. 'To be developed' - This is the inital status, when the component files have been generated but the work to actually build out the code for the component has not started.
+   * ?  2. 'In progress' - This is the status while the component is being built. This lets developers know that the full fuctionality of the component has not been completed and that it may change in the future.
+   * ?  3. 'Baseline completed' - This means the core functionality of the component has been completed and it is ready for use. However, small changes to the component may still occur in the future.
+   * ?  4. 'In use' - This means the component is completed and being using in products. Therefore, developers need to be mindful of its existing uses when making any changes.
+   * &&   statusObject.statusRow determines the sets of ticks/crosses shown below the component name.
+   * &&   The ticks/crosses are separated into rows with one row for each entry of the statusRows array.
+   * &&   Any entries can be included, but by default the following are provided, initally all set to false:
+   * ?  Accessible - The component has been developed with reference to the WCAG guidelines. The component has been checked against our accessibility checklist, including testing it on screen readers.
+   * ?  Responsive - The component has been checked against our mobile design checklist. The component has been tested on multiple mobile devices.
+   * ?  Prog. enhanced - Potential progressive enhancements have been considered, and if appropriate, implemented for this component.
+   * ?  Reviewed - The component requirements, functionality and code have been reviewed and approved.
+   * ?  Tested - The component's use within products or prototyping (i.e. in a real-use example, using real props) has been tested and approved.
+   */
+  let statusObject = {
+    progress: "To be developed",
+    statusRows: [
+      {
+        obj: { Accessible: false, Responsive: false, "Prog. enhanced": false },
+        visibleOnHompepage: false,
+      },
+      {
+        obj: { Reviewed: false, Tested: false },
+        visibleOnHomepage: false,
+      },
+    ],
+  };
+
+  /**
+   * CUSTOMISETHIS  Update detailsArray to provide description of what this component does and when it should be used.
+   * &&   By default the detailsArray includes description and context. The description is intended to explain what the component does, the context is intended to explain when the component will be used.
+   * ?  Within the array, each object has an optional markdown (default = false) parameter. When set to true, it uses the @html tag to render the content (e.g. this can be used for including links to other pages).
+   * ?  You can add other categories to the detailsArray or, if you need a more flexible solution, edit the WrapperInformation snippet directly.
+   *
+   */
+  let descriptionArray = ["Explain here what the component does."];
+
+  let contextArray = [
+    "Explain here the different contexts in which the component should be used.",
+  ];
+
+  let detailsArray = [
+    {
+      label: "Description",
+      arr: descriptionArray,
+      visibleOnHomepage: true,
+      markdown: true,
+    },
+    {
+      label: "Context",
+      arr: contextArray,
+      visibleOnHomepage: false,
+      markdown: true,
+    },
+  ];
+
+  /**
+   * CUSTOMISETHIS  Update connectedComponentsArray to provide links to any children, parent or related components.
+   */
+  let connectedComponentsArray = [];
+</script>
+
+<script>
+  //@ts-nocheck
+  import { page } from "$app/state";
+  import { browser } from "$app/environment";
+
+  import WrapperDetailsUpdate from "$lib/package-wrapping/WrapperDetailsUpdate.svelte";
+  import ParsingErrorToastsContainer from "$lib/package-wrapping/ParsingErrorToastsContainer.svelte";
+  import ComponentDemo from "$lib/package-wrapping/ComponentDemo.svelte";
+
+  import { kebabToPascalCase } from "$lib/utils/text-string-conversion/textStringConversion.js";
+  import { addIndexAndInitalValue } from "$lib/utils/package-wrapping-specific/addIndexAndInitialValue.js";
+  import { createParametersObject } from "$lib/utils/package-wrapping-specific/createParametersObject.js";
+  import { trackVisibleParameters } from "$lib/utils/package-wrapping-specific/trackVisibleParameters.js";
+  import { createBindableParametersValuesArray } from "$lib/utils/package-wrapping-specific/createBindableParametersValuesArray.js";
+  import { getValueFromParametersArray } from "$lib/utils/data-transformations/getValueFromParametersArray.js";
+
+  import { defaultScreenWidthBreakpoints } from "$lib/config.js";
+
+  import CardHeader from "$lib/components/ui/CardHeader.svelte";
+  import Examples from "./card-header/Examples.svelte";
+
+  let { data } = $props();
+
+  /**
+   * DONOTTOUCH *
+   * ? 		uses the page url to identify the name of the component and the folder it belongs to (folder is only used by snippets exported to the homepage to link back to this page).
+   */
+  let pageInfo = page.url.pathname.split("/");
+  let pageName = kebabToPascalCase(pageInfo[pageInfo.length - 1]);
+
+  /**
+   * DONOTTOUCH *
+   * ? 		demoScreenWidth is a reactive variable which tracks which screen size the user has selected for demoing the component
+   */
+  let demoScreenWidth = $state(defaultScreenWidthBreakpoints.md);
+
+  /**
+   * ! Step 2 - Adding binded props
+   * CUSTOMISETHIS  Define any binded props
+   * && 		Any props which are updated inside the component but accessed outside should be declared here using the $state() rune. They can then be added to the parameterSourceArray below.
+   * &&     Also note that they must also be passed to component using the bind: directive (e.g. <ExampleComponent bind:exampleBindableProp>)
+   */
+
+  /**
+   * ! Step 3 - Add your props
+   * CUSTOMISETHIS  Add your parameters to the array.
+   * && 		parametersSourceArray is where you define any props for the component. All props should be listed in the parametersSourceArray.
+   * &&     Initial values should be provided for all props which either (i) are binded, or (ii) can be modified using the demo UI.
+   * &&     Values should also be provided for functions and svelte snippets - which cannot be modified by the user to prevent security issues.
+   * &&     Some props may be derived from other props. These should still be listed in the parametersSourceArray, but their value should be left empty. Their value can then be defined further down the page.
+   * ?      For each prop, the following fields are available:
+   * ? 		  <name> (required, must be unique) -  Name of the parameter which is passed to the component. The name can also be referenced in the calculation of derived parameters which depend on this value.
+   * ?      <category> - (required) - Used for separating parameters into different groups.
+   *
+   * ?      <isBinded> - (optional, default = false) - Should be set to true, if the prop is utilising the bind:directive. Note that for bind to work, the prop must also be defined in step 1 using the $state() rune and passed to the component separately as bindable (e.g. bind:thisProp).
+   *
+   *
+   * ?      <options> - (required for $state() props which can be modified using dropwdown or radio inputs). <options> should contain an array of strings. If <value> is null or absent, the initial value will be taken from the first entry in the options array.
+   * ?      <value> - (Should be null or absent for derived props. For all others props it's required, unless there is an options field). Used to set the initial value of the prop.
+   *
+   * ?      <propType> - (optional) - Has two use cases:
+   * ?      (i) set to 'fixed' to prevent users editing the value.
+   * ?      (i) set to 'radio' to have options selectable via the radio input (uses dropdown by default).
+   *
+   * ?      <visible> - (optional, default = true). Hides prop in the UI if certain conditions are not met. Specify an object with a name - the parameter that you want to check against and a value - the value that the named parameters need to equal for this input to be visible.
+   * ?      The Line component provides an example of the <visible> field in action, showing and hiding props based on <includeMarkers>
+   * ?      If you want the form to be visible only if multiple conditions are met, you can provide an array of conditional objects instead.
+   *
+   * ?      <rows> - (optional, default = 1, only use with $state() where typeof value === "string"). Sets the numbers of rows used by the textArea input.
+   *
+   * ?      <functionElements> - (optional, only used where typeof value === "function") - <functionElements> can have three optional properties:
+   * ?      (i) 'functionAsString': Should be set as a string copy of the function itself. Used to display the function in the demo UI.
+   * ?      (ii) 'counter': For use with event handler functions. Should be set to 0. Then putting 'this.functionElements.counter += 1;' in the function body will cause the counter to update each time the function is triggered.
+   * ?      (iii) 'dataset': For use with event handler fuctions. Should be an object - then putting 'Object.keys(this.functionElements.dataset).forEach((el) => { this.functionElements.dataset[el] = event.currentTarget.dataset[el]; });' in the function body will cause the object to update each time the function is triggered.
+   *
+   * ?      <description> - (optional, but strongly encouraged). Describes what the parameter does and best practice uses for it. The description can be a string, an object with a markdown field (true or false) and arr field, or a svelte snippet.
+   *
+   * ?      <isProp> - (optional, default = true) - Should be set to false for paramters which are not actually passed to the component.
+   * ?      <isRequired> - (optional, default = false) - Should be set to true for any props which the component will not functionally properly without (e.g. props with no default value, props which will cause erros if undefined).
+   *
+   */
+  let parametersSourceArray = $derived(
+    addIndexAndInitalValue([
+      {
+        name: "componentNameProp",
+        category: "Input props",
+        propType: "fixed",
+        value: pageName,
+      },
+      {
+        name: "textProp",
+        category: "Input props",
+        value: `This is a string input - edit me using the UI and see it reflected in the component.`,
+        description: {
+          markdown: true,
+          arr: [
+            `This prop passes a text string to the <code>${pageName}</code> component.`,
+          ],
+        },
+        rows: 2,
+      },
+      {
+        name: "numberProp",
+        category: "Input props",
+        value: 9,
+        description: {
+          markdown: true,
+          arr: [
+            `This prop passes a text string to the <code>${pageName}</code> component.`,
+          ],
+        },
+        rows: 5,
+      },
+      {
+        name: "checkboxProp",
+        category: "Input props",
+        value: false,
+        description: {
+          markdown: true,
+          arr: [
+            `This prop passes <code>false</code> to the component when unchecked, <code>true</code> when checked.`,
+          ],
+        },
+      },
+      {
+        name: "dropdownProp",
+        category: "Input props",
+        options: ["apple", "banana", "kiwi", "strawberry", "orange"],
+        description: {
+          markdown: true,
+          arr: [
+            `This prop passes the selected <code>option</code> to the component as a string.`,
+          ],
+        },
+      },
+      {
+        name: "radioProp",
+        category: "Input props",
+        propType: "radio",
+        options: ["carrot", "potato", "broccoli", "mushroom", "tomato"],
+        description: {
+          markdown: true,
+          arr: [
+            `This prop passes the selected <code>option</code> to the component as a string.`,
+          ],
+        },
+      },
+      {
+        name: "jsObjectProp",
+        category: "Input props",
+        value: [
+          {
+            name: "Pikachu",
+            type: "Electric",
+            color: "#fde047",
+          },
+          {
+            name: "Charmander",
+            type: "Fire",
+            color: "#fca5a5",
+          },
+          {
+            name: "Squirtle",
+            type: "Water",
+            color: "#93c5fd",
+          },
+          {
+            name: "Bulbasaur",
+            type: "Grass",
+            color: "#86efac",
+          },
+        ],
+        description: {
+          markdown: true,
+          arr: [
+            `This prop passes the selected a JS object to the component.`,
+            `The object can be directly edited. A notification will alert the user is any edits create an invalid object`,
+          ],
+        },
+      },
+      {
+        name: "functionProp",
+        category: "Fixed props",
+
+        isRequired: true,
+        value: function (event, pokemon) {
+          window.alert(
+            `The ${this.name} function has been triggered. Open the 'Fixed props' panel to see updated values.`,
+          );
+
+          this.functionElements.counter += 1;
+          Object.keys(this.functionElements.dataset).forEach((el) => {
+            this.functionElements.dataset[el] = event.currentTarget.dataset[el];
+          });
+        },
+        functionElements: {
+          dataset: { role: null, id: null },
+          counter: 0,
+          functionAsString: `function (event, pokemon) {
+window.alert(
+  "The \${this.name} function has been triggered. Open the 'Fixed props' panel to see updated values.",
+);
+
+this.functionElements.counter += 1;
+Object.keys(this.functionElements.dataset).forEach((el) => {
+  this.functionElements.dataset[el] = event.currentTarget.dataset[el];
+});
+}`,
+        },
+        description: {
+          markdown: true,
+          arr: [
+            `This prop passes a function to the ${pageName} component. It works slightly differently to other props.`,
+            `Firstly, it is not editable via the UI.`,
+            `Secondly, the code snippet on the left is not actually based on the value. Instead, it is example code based on the <code>functionElements.functionAsString</code> property, and is optional.`,
+            ,
+            `For event functions, you can define your function so that it updates the <code>functionElements.counter</code> property each time it runs.`,
+            `For event functions, you can also define your function so that it grabs data from its target, which are then stored in <code>functionElements.dataset</code> and displayed in the UI (trigger your event to see this in action).`,
+          ],
+        },
+      },
+    ]),
+  );
+
+  /**
+   * DONOTTOUCH *
+   * && 		Defining functions. generateValuesArray is used to create our arrays which track the $state() and $derived() props. getValue can used to access a reactive value from the $state() based on the prop name.
+   */
+  let generateValuesArray = function (
+    parametersSourceArray,
+    isEditableBoolean,
+    derivedParametersObject,
+  ) {
+    return parametersSourceArray.map((el) => {
+      let value = derivedParametersObject[el.name] ?? el.value;
+
+      return el.isEditable === isEditableBoolean && value != null
+        ? typeof value === "object"
+          ? JSON.stringify(value, null, 2)
+          : value
+        : null;
+    });
+  };
+
+  let getValue = function (fieldName) {
+    return statedParametersValuesArray[
+      parametersSourceArray?.findIndex((el) => el.name === fieldName)
+    ];
+  };
+
+  /**
+   * DONOTTOUCH *
+   * && 		statedParametersValuesArray tracks the values of $state() props as they are modified by the user using the demo UI.
+   */
+  let statedParametersValuesArray = $state(
+    generateValuesArray(parametersSourceArray, true, {}),
+  );
+
+  /**
+   *  !  Step 4 - Define values for derived parameters, and add them to.
+   *  CUSTOMISETHIS  Add any additional parameters which are calculated based on other parameters.
+   *  && 		Here you can define calculations for any additional component parameters which - rather than being set by the user - are calculated based on the value of other parameters.
+   *  &&    Next, add the variables to the derivedParametersObject.
+   *
+   *  &&    (e.g. let derivedProp = $derived(...code for calculating value here), then derivedParametersObject = $derived({ derivedProp }))
+   *
+   *  &&    Note that these parameters still need to be listed in the source array (with a null or absent value).
+   *  &&    You must then also combine them into the derivedParametersObject below so that they are passed to the component.
+   *  &&     The getValue() function can be helpful for deriving props based on the value of $state() prop.
+   */
+
+  let derivedParametersObject = $derived({});
+
+  /**
+   * DONOTTOUCH *
+   * &&     derivedParametersValuesArray tracks the values of $derived() and fixed props.
+   */
+  let derivedParametersValuesArray = $derived(
+    generateValuesArray(parametersSourceArray, false, derivedParametersObject),
+  );
+
+  /**
+   * DONOTTOUCH *
+   * && 		parametersValuesArray's is a one-to-one mapping to the source array which tracks whether a parameter should be visible in the demo UI.
+   */
+  let parametersVisibleArray = $derived(
+    trackVisibleParameters(parametersSourceArray, statedParametersValuesArray),
+  );
+
+  /**
+   * DONOTTOUCH *
+   * && 		parametersObject takes the props to be passed to the component and converts them into a (parameterName: parameterValue) pattern
+   * &&     parametersParsingErrorsArray tracks any errors due to attempting to use JSON.parse() on strings which do not convert to valid JavaScript objects.
+   * &&     $effect() is then use to update parametersParsingErrorsObject, which tracks when errors and fixes occur.
+   */
+
+  let [parametersObject, parametersParsingErrorsArray] = $derived(
+    createParametersObject(
+      parametersSourceArray,
+      statedParametersValuesArray,
+      derivedParametersValuesArray,
+    ),
+  );
+
+  let parametersParsingErrorsObject = $state({});
+
+  $effect(() => {
+    parametersParsingErrorsArray.forEach((el) => {
+      parametersParsingErrorsObject[el] = true;
+    });
+
+    Object.keys(parametersParsingErrorsObject).forEach((el) => {
+      if (!parametersParsingErrorsArray.includes(el)) {
+        parametersParsingErrorsObject[el] = false;
+      }
+    });
+  });
+
+  /**
+   * DONOTTOUCH *
+   * && 		copyParametersToClipboard simply takes the set of props being passed to the component, and replaces any function with their functionAsString property. This is necessary because actual functions cannot be written to parsed into a string, and therefore can't be copied to the clipboard.
+   */
+
+  let copyParametersToClipboardObject = $derived(
+    Object.fromEntries(
+      Object.entries(parametersObject).map(([key, value]) => [
+        key,
+        typeof value === "function"
+          ? parametersSourceArray.find((el) => el.name === key)
+              ?.functionElements?.functionAsString
+          : value,
+      ]),
+    ),
+  );
+</script>
+
+<!--
+&&  WrapperNameAndStatus and WrapperInformation are passed to the WrapperDetails component. They are also exported and then imported on the homepage, and then used (again by the WrapperDetails component) to provide a link and info to this component. 
+  -->
+
+{#snippet WrapperNameAndStatus(name, folder, subFolder, homepage)}
+  <BaseNameAndStatus
+    {name}
+    {folder}
+    {subFolder}
+    {homepage}
+    {statusObject}
+    parentFolder="components-update"
+  ></BaseNameAndStatus>
+{/snippet}
+
+{#snippet WrapperInformation(homepage)}
+  <BaseInformation {homepage} {detailsArray} {connectedComponentsArray}
+  ></BaseInformation>
+{/snippet}
+
+<!-- 
+  !   Step 5 - Create a context for the component and pass in any binded props using the bind:directive
+  CUSTOMISETHIS   Create a context in which your component is commonly used (e.g. wrap chart components within SVGs). Pass through binded props separately (e.g. <Component {...parametersOnject} bind:bindedProp></Component>)
+ -->
+{#snippet Component()}
+  <div class="p-8">
+    <CardHeader {...parametersObject}></CardHeader>
+  </div>
+{/snippet}
+
+<!--
+DONOTTOUCH  *
+&&          Uses snippets to render metadata for the component.
+-->
+<WrapperDetailsUpdate
+  wrapper={{
+    component: { WrapperInformation, WrapperNameAndStatus },
+    name: pageName,
+  }}
+  homepage={false}
+></WrapperDetailsUpdate>
+
+<!-- 
+  DONOTTOUCH  *
+  &&          Renders toast components based on tracking parsing errors and fixes.
+ -->
+<ParsingErrorToastsContainer
+  {parametersParsingErrorsArray}
+  {parametersParsingErrorsObject}
+  onCloseFunction={(key) =>
+    parametersParsingErrorsArray.filter((el) => el != key)}
+></ParsingErrorToastsContainer>
+
+<!--
+    DONOTTOUCH  *
+    &&          Renders the demo UI and the component itself.
+-->
+<ComponentDemo
+  {Component}
+  bind:demoScreenWidth
+  {parametersSourceArray}
+  bind:statedParametersValuesArray
+  {derivedParametersValuesArray}
+  {parametersVisibleArray}
+  {parametersParsingErrorsObject}
+  {copyParametersToClipboardObject}
+></ComponentDemo>
+
+<!--
+    DONOTTOUCH  *
+    &&          Creates a list of examples where the component is used (if any examples exist).
+-->
+<div id="examples" data-role="examples-section">
+  <Examples></Examples>
+</div>

--- a/src/wrappers/components/ui/CardHeader/card-header/Examples.svelte
+++ b/src/wrappers/components/ui/CardHeader/card-header/Examples.svelte
@@ -1,0 +1,48 @@
+<script>
+  import { AccordionItem, Accordion } from "flowbite-svelte";
+
+  import CodeBlock from "$lib/package-wrapping/CodeBlock.svelte";
+  import * as codeBlocks from "./codeBlocks.js";
+
+  import CardHeader from "$lib/components/ui/CardHeader.svelte";
+
+  let accordionSnippetSections = [
+    {
+      id: "1",
+      heading: "1. Example 1 - describe the use case here",
+      content: Example1,
+    },
+  ];
+</script>
+
+<div>
+  <h5 class="underline underline-offset-4 my-6">
+    Examples of specific use cases
+  </h5>
+  <Accordion
+    activeClass="text-[#EA580C] focus:ring-2 focus:ring-[#EA580C]"
+    inactiveClass="text-gray-500 dark:text-gray-400 hover:bg-slate-100"
+    defaultClass="w-full"
+  >
+    {#each accordionSnippetSections as section}
+      <AccordionItem>
+        <span slot="header" class="text-lg">{section.heading}</span>
+        <div class="bg-orange-50 p-5 flex flex-col gap-8">
+          {@render section.content()}
+        </div>
+      </AccordionItem>
+    {/each}
+  </Accordion>
+</div>
+
+{#snippet Example1()}
+  <div class="p-5 bg-white">
+    <div class="card" style="width: 300px">
+      <CardHeader></CardHeader>
+      <div class="body">
+        <p>This is text in the body of the card.</p>
+      </div>
+    </div>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+{/snippet}

--- a/src/wrappers/components/ui/CardHeader/card-header/codeBlocks.js
+++ b/src/wrappers/components/ui/CardHeader/card-header/codeBlocks.js
@@ -1,0 +1,32 @@
+export const codeBlock1 = `
+<script>
+
+  import Template from "$lib/package-wrapping/Template.svelte";
+
+</script>
+
+<Template
+checkboxProp={true}
+dropdownProp="Dragonfruit"
+jsObjectProp={[
+  {
+    name: "Borussia Dortmund",
+    country: "Germany",
+    color: "#fdff7d",
+  },
+  { name: "Liverpool FC", country: "UK", color: "#f59fad" },
+  {
+    name: "SSC Napoli",
+    country: "Italy",
+    color: "#69bfff",
+  },
+  {
+    name: "S.L. Benfica",
+    country: "Portugal",
+    color: "#ff8c96",
+  },
+]}
+functionProp={function (event, pokemon) {
+  window.alert("Example 1 functionProp has been triggered.");
+}}
+></Template>`;

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -163,7 +163,7 @@
   let parametersSourceArray = $derived(
     addIndexAndInitalValue([
       {
-        name: "linkCard",
+        name: "headingIsLink",
         category: "Content",
         value: true,
       },

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -56,6 +56,7 @@
     "They can be used on the home page to indicate the main functions of the service or options to the user. In this case they should be styled to make them prominent.",
     "They can be used as links to supplementary content or information too.",
     "They can be used in a grid layout as an alternative to a more simple list of items. The benefit of cards is that they can include content like graphics or charts which make them more engaging than a list of plain text links.",
+    "The dashed border around the card is only there to help you see the card on this wrapper page.",
   ];
 
   let detailsArray = [
@@ -412,7 +413,9 @@
  -->
 {#snippet Component()}
   <div class="p-8">
-    <Card {...parametersObject}></Card>
+    <div style="border: 1px dashed grey;">
+      <Card {...parametersObject}></Card>
+    </div>
   </div>
 {/snippet}
 

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -184,6 +184,17 @@
         },
       },
       {
+        name: "headerTextSize",
+        category: "Card header",
+        value: `1.5rem`,
+        description: {
+          markdown: true,
+          arr: [
+            `This is the header font size. Set to 1.5 * the root by default.`,
+          ],
+        },
+      },
+      {
         name: "href",
         category: "Card header",
         value: `/download-all`,

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -163,24 +163,44 @@
   let parametersSourceArray = $derived(
     addIndexAndInitalValue([
       {
-        name: "headingIsLink",
+        name: "headerIsLink",
         category: "Content",
         value: true,
+        description: {
+          markdown: true,
+          arr: [
+            `This is a boolean prop which is set to true by default. If true you get the govuk styled header with a chevron svg on the right-hand side.`,
+          ],
+        },
       },
       {
         name: "linkText",
         category: "Content",
         value: `Download data`,
+        description: {
+          markdown: true,
+          arr: [`This is the header text. headerIsLink must be true.`],
+        },
       },
       {
         name: "onlyTextInBody",
         category: "Content",
         value: true,
+        description: {
+          markdown: true,
+          arr: [
+            `Set to true when there is plain text in the bottom section of the card. It is true by default.`,
+          ],
+        },
       },
       {
         name: "bodyText",
         category: "Content",
         value: `This is the text that gives more information about the call to action in the card heading.`,
+        description: {
+          markdown: true,
+          arr: [`This is the body text. onlyTextInBody must be true.`],
+        },
       },
       {
         name: "linkTextColor",
@@ -191,31 +211,59 @@
         name: "bodyTextColor",
         category: "Colours",
         value: `#0B0C0C`,
+        description: {
+          markdown: true,
+          arr: [
+            `The color of the text in the body. onlyTextInBody must be true. Text color must be specified in snippets or children if you are passing them.`,
+          ],
+        },
       },
       {
-        name: "callToActionBackgroundColor",
+        name: "headerBackgroundColor",
         category: "Colours",
         value: `white`,
+        description: {
+          markdown: true,
+          arr: [`The background color of the header section of the card.`],
+        },
       },
       {
         name: "bodyBackgroundColor",
         category: "Colours",
         value: `#FBFCFD`,
+        description: {
+          markdown: true,
+          arr: [`The background color of the body section of the card.`],
+        },
       },
       {
         name: "bodyTopBorderColor",
         category: "Colours",
         value: `#F4F8FB`,
+        description: {
+          markdown: true,
+          arr: [`The color of the top border of the body section of the card.`],
+        },
       },
       {
         name: "bodyBottomBorderColor",
         category: "Colours",
         value: `#c3d9e9`,
+        description: {
+          markdown: true,
+          arr: [
+            `The color of the bottom border of the body section of the card.`,
+          ],
+        },
       },
       {
         name: "href",
         category: "href",
         value: `/download-all`,
+        description: {
+          markdown: true,
+          arr: [`Hyperlink URL. headerIsLink must be true.`],
+        },
       },
     ]),
   );

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -163,59 +163,59 @@
   let parametersSourceArray = $derived(
     addIndexAndInitalValue([
       {
-        name: "cardWidth",
-        category: "Input props",
-        value: `100%`,
-      },
-      {
         name: "linkCard",
-        category: "Input props",
+        category: "Content",
         value: true,
       },
       {
         name: "linkText",
-        category: "Input props",
+        category: "Content",
         value: `Download data`,
       },
       {
-        name: "linkTextColor",
-        category: "Input props",
-        value: `#1D70B8`,
-      },
-      {
-        name: "href",
-        category: "Input props",
-        value: `/download-all`,
-      },
-      {
-        name: "callToActionBackgroundColor",
-        category: "Input props",
-        value: `white`,
+        name: "onlyTextInBody",
+        category: "Content",
+        value: true,
       },
       {
         name: "bodyText",
-        category: "Input props",
+        category: "Content",
         value: `This is the text that gives more information about the call to action in the card heading.`,
       },
       {
+        name: "linkTextColor",
+        category: "Colours",
+        value: `#1D70B8`,
+      },
+      {
         name: "bodyTextColor",
-        category: "Input props",
+        category: "Colours",
         value: `#0B0C0C`,
       },
       {
+        name: "callToActionBackgroundColor",
+        category: "Colours",
+        value: `white`,
+      },
+      {
         name: "bodyBackgroundColor",
-        category: "Input props",
+        category: "Colours",
         value: `#FBFCFD`,
       },
       {
         name: "bodyTopBorderColor",
-        category: "Input props",
+        category: "Colours",
         value: `#F4F8FB`,
       },
       {
         name: "bodyBottomBorderColor",
-        category: "Input props",
+        category: "Colours",
         value: `#c3d9e9`,
+      },
+      {
+        name: "href",
+        category: "href",
+        value: `/download-all`,
       },
     ]),
   );

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -46,10 +46,16 @@
    * ?  You can add other categories to the detailsArray or, if you need a more flexible solution, edit the WrapperInformation snippet directly.
    *
    */
-  let descriptionArray = ["Explain here what the component does."];
+  let descriptionArray = [
+    "The card component acts a signpost for a user. It is a way for users to find the content on your service that is most relevant to them. It could be a link or something more complex like a search component, which lets the user find what they want.",
+    "It also gives the user some information about the content they would see so that they know whether to click on it or not.",
+  ];
 
   let contextArray = [
-    "Explain here the different contexts in which the component should be used.",
+    "There are multiple contexts where cards are appropriate.",
+    "They can be used on the home page to indicate the main functions of the service or options to the user. In this case they should be styled to make them prominent.",
+    "They can be used as links to supplementary content or information too.",
+    "They can be used in a grid layout as an alternative to a more simple list of items. The benefit of cards is that they can include content like graphics or charts which make them more engaging than a list of plain text links.",
   ];
 
   let detailsArray = [

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -164,7 +164,7 @@
     addIndexAndInitalValue([
       {
         name: "headerIsLink",
-        category: "Content",
+        category: "Card header",
         value: true,
         description: {
           markdown: true,
@@ -174,8 +174,8 @@
         },
       },
       {
-        name: "linkText",
-        category: "Content",
+        name: "headerText",
+        category: "Card header",
         value: `Download data`,
         description: {
           markdown: true,
@@ -183,8 +183,17 @@
         },
       },
       {
+        name: "href",
+        category: "Card header",
+        value: `/download-all`,
+        description: {
+          markdown: true,
+          arr: [`Hyperlink URL. headerIsLink must be true.`],
+        },
+      },
+      {
         name: "onlyTextInBody",
-        category: "Content",
+        category: "Card body",
         value: true,
         description: {
           markdown: true,
@@ -195,7 +204,7 @@
       },
       {
         name: "bodyText",
-        category: "Content",
+        category: "Card body",
         value: `This is the text that gives more information about the call to action in the card heading.`,
         description: {
           markdown: true,
@@ -203,18 +212,13 @@
         },
       },
       {
-        name: "linkTextColor",
+        name: "headerTextColor",
         category: "Colours",
         value: `#1D70B8`,
-      },
-      {
-        name: "bodyTextColor",
-        category: "Colours",
-        value: `#0B0C0C`,
         description: {
           markdown: true,
           arr: [
-            `The color of the text in the body. onlyTextInBody must be true. Text color must be specified in snippets or children if you are passing them.`,
+            `The color of the text in the header. It depends on headerIsLink being true. [Currently not working]`,
           ],
         },
       },
@@ -225,6 +229,17 @@
         description: {
           markdown: true,
           arr: [`The background color of the header section of the card.`],
+        },
+      },
+      {
+        name: "bodyTextColor",
+        category: "Colours",
+        value: `#0B0C0C`,
+        description: {
+          markdown: true,
+          arr: [
+            `The color of the text in the body. onlyTextInBody must be true. Text color must be specified in snippets or children if you are passing them.`,
+          ],
         },
       },
       {
@@ -254,15 +269,6 @@
           arr: [
             `The color of the bottom border of the body section of the card.`,
           ],
-        },
-      },
-      {
-        name: "href",
-        category: "href",
-        value: `/download-all`,
-        description: {
-          markdown: true,
-          arr: [`Hyperlink URL. headerIsLink must be true.`],
         },
       },
     ]),

--- a/src/wrappers/components/ui/CardWrapper.svelte
+++ b/src/wrappers/components/ui/CardWrapper.svelte
@@ -26,14 +26,14 @@
    * ?  Tested - The component's use within products or prototyping (i.e. in a real-use example, using real props) has been tested and approved.
    */
   let statusObject = {
-    progress: "To be developed",
+    progress: "In use",
     statusRows: [
       {
-        obj: { Accessible: false, Responsive: false, "Prog. enhanced": false },
+        obj: { Accessible: true, Responsive: true, "Prog. enhanced": true },
         visibleOnHompepage: false,
       },
       {
-        obj: { Reviewed: false, Tested: false },
+        obj: { Reviewed: true, Tested: true },
         visibleOnHomepage: false,
       },
     ],

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -5,7 +5,6 @@
   import * as codeBlocks from "./codeBlocks.js";
 
   import Card from "$lib/components/ui/Card.svelte";
-
   import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
   import PostcodeOrAreaSearch from "$lib/components/ui/PostcodeOrAreaSearch.svelte";
 
@@ -23,8 +22,13 @@
     {
       id: "3",
       heading:
-        "3. Example 3 - a card with a search component instead heading link",
+        "3. Example 3 - a card with a search component instead of a heading link",
       content: Example3,
+    },
+    {
+      id: "4",
+      heading: "4. Example 4 - a card with a link in the body",
+      content: Example4,
     },
   ];
 </script>
@@ -66,13 +70,13 @@
       linkCard={true}
       linkText="Adult social care quality"
       onlyTextInBody={false}
-      {cardBottomSnippet}
+      cardBottomSnippet={cardBottomSnippet1}
     ></Card>
   </div>
-  <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+  <CodeBlock code={codeBlocks.codeBlock2} language="svelte"></CodeBlock>
 {/snippet}
 
-{#snippet cardBottomSnippet()}
+{#snippet cardBottomSnippet1()}
   <PositionChart
     value="4.5"
     min="0"
@@ -93,7 +97,7 @@
       {cardTopSnippet}
     ></Card>
   </div>
-  <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+  <CodeBlock code={codeBlocks.codeBlock3} language="svelte"></CodeBlock>
 {/snippet}
 
 {#snippet cardTopSnippet()}
@@ -112,4 +116,23 @@
     label_id="postcode-search"
     wrap_label_in_a_heading={true}
   ></PostcodeOrAreaSearch>
+{/snippet}
+
+{#snippet Example4()}
+  <div class="p-5 bg-white">
+    <Card
+      linkCard={true}
+      linkText="Download local outcomes data"
+      onlyTextInBody={false}
+      cardBottomSnippet={cardBottomSnippet2}
+    ></Card>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock4} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet cardBottomSnippet2()}
+  <p>
+    Download the complete, latest Local Government Outcomes Framework data.
+    Alternatively <a href="">search for an area</a> and download what you need
+  </p>
 {/snippet}

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -7,17 +7,24 @@
   import Card from "$lib/components/ui/Card.svelte";
 
   import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
+  import PostcodeOrAreaSearch from "$lib/components/ui/PostcodeOrAreaSearch.svelte";
 
   let accordionSnippetSections = [
     {
       id: "1",
-      heading: "1. Example 1 - simple card with heading link, and body text",
+      heading: "1. Example 1 - a simple card with heading link, and body text",
       content: Example1,
     },
     {
       id: "2",
-      heading: "2. Example 2 - card with a chart",
+      heading: "2. Example 2 - a card with a chart in the body",
       content: Example2,
+    },
+    {
+      id: "3",
+      heading:
+        "3. Example 3 - a card with a search component instead heading link",
+      content: Example3,
     },
   ];
 </script>
@@ -66,5 +73,43 @@
 {/snippet}
 
 {#snippet cardBottomSnippet()}
-  <PositionChart></PositionChart>
+  <PositionChart
+    value="4.5"
+    min="0"
+    max="10"
+    annotation="East Sussex"
+    showAxis={false}
+    chartHeight={30}
+  ></PositionChart>
+  <p class="pt-4 pl-3">East Sussex: around average.</p>
+{/snippet}
+
+{#snippet Example3()}
+  <div class="p-5 bg-white">
+    <Card
+      linkCard={false}
+      onlyTextInBody={true}
+      bodyText="The interaction in the card header is a search component instead of a link."
+      {cardTopSnippet}
+    ></Card>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet cardTopSnippet()}
+  <PostcodeOrAreaSearch
+    hint=""
+    label_text="Search for a postcode"
+    label_size="m"
+    placeholder="e.g. NG8 5GT"
+    margin_bottom="2"
+    autoFocusSubmitOnSelection={true}
+    hideHint={false}
+    autoselect={false}
+    customPlacesData={[]}
+    customSourceSelector={() => "api"}
+    minLength={3}
+    label_id="postcode-search"
+    wrap_label_in_a_heading={true}
+  ></PostcodeOrAreaSearch>
 {/snippet}

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -254,9 +254,9 @@
       {#each metrics as { metric, value }}
         <Card
           headerIsLink={true}
-          headerText={metric}
-          headerSize="s"
+          text={metric}
           onlyTextInBody={false}
+          fontSize="1.25rem"
           ><PositionChart {value} min="0" max="10" chartHeight="20"
           ></PositionChart>
         </Card>

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -53,16 +53,53 @@
   ];
 
   const metrics = [
-    { metric: "Adult social care", value: 3 },
-    { metric: "Best start in life", value: 8 },
-    { metric: "Transport and local infrastructure", value: 4 },
-    { metric: "Housing", value: 1 },
-    { metric: "Neighbourhoods", value: 1 },
-    { metric: "Homelessness and rough sleeping", value: 6 },
-    { metric: "Environment, waste and climate change", value: 1 },
-    { metric: "Every child achieving and thriving", value: 1 },
-    { metric: "Adult social care independence", value: 6 },
+    { metric: "Adult social care", value: 3, words: "could improve" },
+    { metric: "Best start in life", value: 8, words: "doing well" },
+    {
+      metric: "Transport and local infrastructure",
+      value: 4,
+      words: "around average",
+    },
+    { metric: "Housing", value: 1, words: "could improve" },
+    { metric: "Neighbourhoods", value: 1, words: "could improve" },
+    {
+      metric: "Homelessness and rough sleeping",
+      value: 6,
+      words: "around average",
+    },
+    {
+      metric: "Environment, waste and climate change",
+      value: 1,
+      words: "could improve",
+    },
+    {
+      metric: "Every child achieving and thriving",
+      value: 1,
+      words: "could improve",
+    },
+    {
+      metric: "Adult social care independence",
+      value: 6,
+      words: "around average",
+    },
   ];
+
+  const columns = 2;
+
+  function position(cardIndex) {
+    const baseItemIndex = cardIndex * 2;
+
+    return [0, 1].map((offset) => {
+      const itemIndex = baseItemIndex + offset;
+
+      const pairIndex = Math.floor(itemIndex / 2);
+      const col = (pairIndex % columns) + 1;
+      const rowBlock = Math.floor(pairIndex / columns);
+      const row = rowBlock * 2 + (itemIndex % 2 === 0 ? 1 : 2);
+
+      return { row, col };
+    });
+  }
 </script>
 
 <div>
@@ -258,25 +295,25 @@
       complexity to the component for only one use case.
     </p>
     <p class="pb-6">display: grid; grid-template-rows: 50% 50%;</p>
-    <div class="card-grid">
-      {#each metrics as { metric, value }}
+    <div
+      class="card-grid"
+      style="display: grid; grid-template-columns: repeat({columns}, 1fr); gap: 0 1rem;"
+    >
+      {#each metrics as { metric, value, words }, i}
         <Card
           headerIsLink={true}
           headerText={metric}
           onlyTextInBody={false}
           headerTextSize="1.25rem"
+          gridPosition={position(i)}
+          display="contents"
           ><PositionChart {value} min="0" max="10" chartHeight="20"
           ></PositionChart>
+          <p class="pl-3" style="font-size: 1.1rem">
+            East Sussex: {words}
+          </p>
         </Card>
       {/each}
     </div>
   </div>
 {/snippet}
-
-<style>
-  .card-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-  }
-</style>

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -248,7 +248,7 @@
     <p class="pb-6">
       The charts must be called as a child component rather than a snippet for
       this to work. If you're using a snippet you can achieve this with
-      ''...restProps'.
+      '...restProps'.
     </p>
     <div class="card-grid">
       {#each metrics as { metric, value }}

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -30,6 +30,16 @@
       heading: "4. Example 4 - a card with a link in the body",
       content: Example4,
     },
+    {
+      id: "5",
+      heading: "5. Example 5 - multiple cards",
+      content: Example5,
+    },
+    // {
+    //   id: "6",
+    //   heading: "6. Example 6 - render children in top and bottom",
+    //   content: Example6,
+    // },
   ];
 </script>
 
@@ -55,8 +65,13 @@
 
 {#snippet Example1()}
   <div class="p-5 bg-white">
+    <p>
+      This is the default card. If you don't pass any snippets or childen into
+      the component you get this. headingIsLink and onlyTextInBody are set to
+      true by default.
+    </p>
     <Card
-      linkCard={true}
+      headingIsLink={true}
       linkText="Card heading"
       bodyText="Text in the body of the card"
     ></Card>
@@ -67,31 +82,28 @@
 {#snippet Example2()}
   <div class="p-5 bg-white">
     <Card
-      linkCard={true}
+      headingIsLink={true}
       linkText="Adult social care quality"
       onlyTextInBody={false}
-      cardBottomSnippet={cardBottomSnippet1}
-    ></Card>
+    >
+      <PositionChart
+        value="4.5"
+        min="0"
+        max="10"
+        annotation="East Sussex"
+        showAxis={false}
+        chartHeight={30}
+      ></PositionChart>
+      <p class="pt-4 pl-3">East Sussex: around average.</p></Card
+    >
   </div>
   <CodeBlock code={codeBlocks.codeBlock2} language="svelte"></CodeBlock>
-{/snippet}
-
-{#snippet cardBottomSnippet1()}
-  <PositionChart
-    value="4.5"
-    min="0"
-    max="10"
-    annotation="East Sussex"
-    showAxis={false}
-    chartHeight={30}
-  ></PositionChart>
-  <p class="pt-4 pl-3">East Sussex: around average.</p>
 {/snippet}
 
 {#snippet Example3()}
   <div class="p-5 bg-white">
     <Card
-      linkCard={false}
+      headingIsLink={false}
       onlyTextInBody={true}
       bodyText="The interaction in the card header is a search component instead of a link."
       {cardTopSnippet}
@@ -115,24 +127,48 @@
     minLength={3}
     label_id="postcode-search"
     wrap_label_in_a_heading={true}
-  ></PostcodeOrAreaSearch>
-{/snippet}
+  ></PostcodeOrAreaSearch>{/snippet}
 
 {#snippet Example4()}
   <div class="p-5 bg-white">
     <Card
-      linkCard={true}
+      headingIsLink={true}
       linkText="Download local outcomes data"
       onlyTextInBody={false}
-      cardBottomSnippet={cardBottomSnippet2}
-    ></Card>
+    >
+      <p>
+        Download the complete, latest Local Government Outcomes Framework data.
+        Alternatively <a href="">search for an area</a> and download what you need
+      </p></Card
+    >
   </div>
   <CodeBlock code={codeBlocks.codeBlock4} language="svelte"></CodeBlock>
 {/snippet}
 
-{#snippet cardBottomSnippet2()}
-  <p>
-    Download the complete, latest Local Government Outcomes Framework data.
-    Alternatively <a href="">search for an area</a> and download what you need
-  </p>
+{#snippet Example5()}
+  <div class="p-5 bg-white">
+    {#each [1, 2, 3] as number}
+      <Card
+        headingIsLink={true}
+        linkText="Adult social care quality"
+        onlyTextInBody={false}
+        ><PositionChart value={number} min="0" max="10"></PositionChart>
+        <p>some text</p></Card
+      >
+    {/each}
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
 {/snippet}
+
+<!-- {#snippet Example6()}
+  <div class="p-5 bg-white">
+    <Card
+      linkCard={false}
+      linkText="Adult social care quality"
+      onlyTextInBody={false}
+      ><PositionChart value="4.5" min="0" max="10"></PositionChart>
+      <PostcodeOrAreaSearch></PostcodeOrAreaSearch></Card
+    >
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
+{/snippet} -->

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -245,18 +245,26 @@
       Multiple cards with charts in a grid using an each block. A metric name
       and value is passed down through the card and into the chart.
     </p>
-    <p class="pb-6">
+    <p>
       The charts must be called as a child component rather than a snippet for
       this to work. If you're using a snippet you can achieve this with
       '...restProps'.
     </p>
+    <p>
+      In this example the headers and the charts are not aligned across the same
+      row and I haven't come up with a satisfactory solution. Making each card a
+      grid container and setting the row heights to fixed fractions of the card
+      height (see below) does solve the problem, but it means adding lots of
+      complexity to the component for only one use case.
+    </p>
+    <p class="pb-6">display: grid; grid-template-rows: 50% 50%;</p>
     <div class="card-grid">
       {#each metrics as { metric, value }}
         <Card
           headerIsLink={true}
-          text={metric}
+          headerText={metric}
           onlyTextInBody={false}
-          fontSize="1.25rem"
+          headerTextSize="1.25rem"
           ><PositionChart {value} min="0" max="10" chartHeight="20"
           ></PositionChart>
         </Card>

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -51,6 +51,18 @@
       content: Example7,
     },
   ];
+
+  const metrics = [
+    { metric: "Adult social care", value: 3 },
+    { metric: "Best start in life", value: 8 },
+    { metric: "Transport and local infrastructure", value: 4 },
+    { metric: "Housing", value: 1 },
+    { metric: "Neighbourhoods", value: 1 },
+    { metric: "Homelessness and rough sleeping", value: 6 },
+    { metric: "Environment, waste and climate change", value: 1 },
+    { metric: "Every child achieving and thriving", value: 1 },
+    { metric: "Adult social care independence", value: 6 },
+  ];
 </script>
 
 <div>
@@ -229,13 +241,34 @@
 
 {#snippet Example7()}
   <div class="p-5 bg-white">
-    {#each [1, 2, 3] as number}
-      <Card
-        headerIsLink={true}
-        headerText="Adult social care quality"
-        onlyTextInBody={false}
-        ><PositionChart value={number} min="0" max="10"></PositionChart>
-      </Card>
-    {/each}
+    <p>
+      Multiple cards with charts in a grid using an each block. A metric name
+      and value is passed down through the card and into the chart.
+    </p>
+    <p class="pb-6">
+      The charts must be called as a child component rather than a snippet for
+      this to work. If you're using a snippet you can achieve this with
+      ''...restProps'.
+    </p>
+    <div class="card-grid">
+      {#each metrics as { metric, value }}
+        <Card
+          headerIsLink={true}
+          headerText={metric}
+          headerSize="s"
+          onlyTextInBody={false}
+          ><PositionChart {value} min="0" max="10" chartHeight="20"
+          ></PositionChart>
+        </Card>
+      {/each}
+    </div>
   </div>
 {/snippet}
+
+<style>
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+</style>

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -71,7 +71,7 @@
       true by default.
     </p>
     <Card
-      headingIsLink={true}
+      headerIsLink={true}
       linkText="Card heading"
       bodyText="Text in the body of the card"
     ></Card>
@@ -82,7 +82,7 @@
 {#snippet Example2()}
   <div class="p-5 bg-white">
     <Card
-      headingIsLink={true}
+      headerIsLink={true}
       linkText="Adult social care quality"
       onlyTextInBody={false}
     >
@@ -103,16 +103,16 @@
 {#snippet Example3()}
   <div class="p-5 bg-white">
     <Card
-      headingIsLink={false}
+      headerIsLink={false}
       onlyTextInBody={true}
       bodyText="The interaction in the card header is a search component instead of a link."
-      {cardTopSnippet}
+      {headerSnippet}
     ></Card>
   </div>
   <CodeBlock code={codeBlocks.codeBlock3} language="svelte"></CodeBlock>
 {/snippet}
 
-{#snippet cardTopSnippet()}
+{#snippet headerSnippet()}
   <PostcodeOrAreaSearch
     hint=""
     label_text="Search for a postcode"
@@ -132,7 +132,7 @@
 {#snippet Example4()}
   <div class="p-5 bg-white">
     <Card
-      headingIsLink={true}
+      headerIsLink={true}
       linkText="Download local outcomes data"
       onlyTextInBody={false}
     >
@@ -149,7 +149,7 @@
   <div class="p-5 bg-white">
     {#each [1, 2, 3] as number}
       <Card
-        headingIsLink={true}
+        headerIsLink={true}
         linkText="Adult social care quality"
         onlyTextInBody={false}
         ><PositionChart value={number} min="0" max="10"></PositionChart>
@@ -157,7 +157,6 @@
       >
     {/each}
   </div>
-  <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
 {/snippet}
 
 <!-- {#snippet Example6()}

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -45,11 +45,11 @@
         "6. Example 6 - a card with non-standard content in the header and body",
       content: Example6,
     },
-    // {
-    //   id: "7",
-    //   heading: "7. Example 7 - multiple cards in a grid with dynamic props",
-    //   content: Example7,
-    // }
+    {
+      id: "7",
+      heading: "7. Example 7 - multiple cards in a grid with dynamic props",
+      content: Example7,
+    },
   ];
 </script>
 
@@ -196,28 +196,38 @@
 {#snippet Example6()}
   <div class="p-5 bg-white">
     <p>
-      If you something more complex in the body you can pass a snippet or child
-      component.
+      If you want something more complex in the header and the body you can pass
+      a snippet and a child component respectively or you can pass a snippet to
+      each. The reason the child option is only available to the body is because
+      with two '@render children' in the component it renders all children in
+      both places it is called (there might be a way around this).
     </p>
     <p class="pb-6">
-      In this example a chart is passed in as a child component.
+      In this example the postcode search component is passed into the header
+      with a snippet and some text with a link is passed into body via children.
     </p>
     <Card
       headerIsLink={false}
       headerText="Adult social care quality"
       onlyTextInBody={false}
       headerSnippet={headerSnippet2}
-      ><InsetText></InsetText>
+      ><p>Some text with a <a href="">link</a></p>
     </Card>
   </div>
-  <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
+  <CodeBlock code={codeBlocks.codeBlock6} language="svelte"></CodeBlock>
 {/snippet}
 
 {#snippet headerSnippet2()}
-  <Button buttonType="default" textContent="Click me"></Button>
+  <PostcodeOrAreaSearch
+    label_text="Search for a postcode"
+    placeholder="e.g. NG8 5GT"
+    margin_bottom="2"
+    customPlacesData={[]}
+    customSourceSelector={() => "api"}
+  ></PostcodeOrAreaSearch>
 {/snippet}
 
-<!-- {#snippet Example5()}
+{#snippet Example7()}
   <div class="p-5 bg-white">
     {#each [1, 2, 3] as number}
       <Card
@@ -225,8 +235,7 @@
         headerText="Adult social care quality"
         onlyTextInBody={false}
         ><PositionChart value={number} min="0" max="10"></PositionChart>
-        <p>some text</p></Card
-      >
+      </Card>
     {/each}
   </div>
-{/snippet} -->
+{/snippet}

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -86,7 +86,7 @@
 </div>
 
 {#snippet Example1()}
-  <div class="p-5 bg-white">
+  <div class="p-5 bg-grey">
     <p>
       This is the default card. If you don't pass any snippets or childen into
       the component you get this.
@@ -105,7 +105,7 @@
 {/snippet}
 
 {#snippet Example2()}
-  <div class="p-5 bg-white">
+  <div class="p-5 bg-grey">
     <p class="pb-6">
       A card with different colors for the text, background and borders.
     </p>
@@ -122,7 +122,7 @@
 {/snippet}
 
 {#snippet Example3()}
-  <div class="p-5 bg-white">
+  <div class="p-5 bg-grey">
     <p class="pb-6">
       A card with a snippet passed to the header instead of the default link and
       chevron. In this example the snippet contains the postcode search
@@ -148,7 +148,7 @@
   ></PostcodeOrAreaSearch>{/snippet}
 
 {#snippet Example4()}
-  <div class="p-5 bg-white">
+  <div class="p-5 bg-grey">
     <p>
       If you want something more complex in the body you can pass a snippet or a
       child component.
@@ -179,7 +179,7 @@
 {/snippet}
 
 {#snippet Example5()}
-  <div class="p-5 bg-white">
+  <div class="p-5 bg-grey">
     <p>
       If you want something more complex in the body you can pass a snippet or a
       child component.
@@ -206,7 +206,7 @@
 {/snippet}
 
 {#snippet Example6()}
-  <div class="p-5 bg-white">
+  <div class="p-5 bg-grey">
     <p>
       If you want something more complex in the header and the body you can pass
       a snippet and a child component respectively or you can pass a snippet to
@@ -240,7 +240,7 @@
 {/snippet}
 
 {#snippet Example7()}
-  <div class="p-5 bg-white">
+  <div class="p-5 bg-grey">
     <p>
       Multiple cards with charts in a grid using an each block. A metric name
       and value is passed down through the card and into the chart.

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -20,26 +20,34 @@
       heading: "2. Example 2 - a card with different colors",
       content: Example2,
     },
+    {
+      id: "3",
+      heading: "3. Example 3 - a card with a search component in the header",
+      content: Example3,
+    },
+    {
+      id: "4",
+      heading:
+        "4. Example 4 - a card with a chart in the body using the snippet method",
+      content: Example4,
+    },
+    {
+      id: "5",
+      heading:
+        "5. Example 5 - a card with a chart in the body using the children method",
+      content: Example5,
+    },
     // {
-    //   id: "2",
-    //   heading: "2. Example 2 - a card with a chart in the body",
-    //   content: Example2,
-    // },
-    // {
-    //   id: "3",
+    //   id: "6",
     //   heading:
-    //     "3. Example 3 - a card with a search component instead of a heading link",
-    //   content: Example3,
+    //     "6. Example 6 - a card with non-standard content in header and body",
+    //   content: Example6,
     // },
     // {
-    //   id: "4",
-    //   heading: "4. Example 4 - a card with a link in the body",
-    //   content: Example4,
-    // },
-    // {
-    //   id: "5",
-    //   heading: "5. Example 5 - multiple cards",
-    //   content: Example5,
+    //   id: "7",
+    //   heading: "7. Example 7 - multiple cards in a grid with dynamic props",
+    //   content: Example7,
+    // }
   ];
 </script>
 
@@ -96,17 +104,80 @@
       bodyTopBorderColor="purple"
     ></Card>
   </div>
-  <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+  <CodeBlock code={codeBlocks.codeBlock2} language="svelte"></CodeBlock>
 {/snippet}
 
-<!-- {#snippet Example2()}
+{#snippet Example3()}
   <div class="p-5 bg-white">
+    <p class="pb-6">
+      A card with a snippet passed to the header instead of the default link and
+      chevron. In this example the snippet contains the postcode search
+      component.
+    </p>
+    <Card
+      headerIsLink={false}
+      onlyTextInBody={true}
+      bodyText="Enter your postcode to find out about deprivation in your local area."
+      {headerSnippet}
+    ></Card>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock3} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet headerSnippet()}
+  <PostcodeOrAreaSearch
+    label_text="Search for a postcode"
+    placeholder="e.g. NG8 5GT"
+    margin_bottom="2"
+    customPlacesData={[]}
+    customSourceSelector={() => "api"}
+  ></PostcodeOrAreaSearch>{/snippet}
+
+{#snippet Example4()}
+  <div class="p-5 bg-white">
+    <p>
+      If you something more complex in the body you can pass a snippet or child
+      component.
+    </p>
+    <p class="pb-6">
+      In this example a chart is passed in using the snippet method.
+    </p>
     <Card
       headerIsLink={true}
       headerText="Adult social care quality"
       onlyTextInBody={false}
-    >
-      <PositionChart
+      {bodySnippet}
+    ></Card>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock4} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet bodySnippet()}
+  <PositionChart
+    value="4.5"
+    min="0"
+    max="10"
+    annotation="East Sussex"
+    showAxis={false}
+    chartHeight={30}
+  ></PositionChart>
+  <p class="pt-4 pl-3">East Sussex: around average.</p>
+{/snippet}
+
+{#snippet Example5()}
+  <div class="p-5 bg-white">
+    <p>
+      If you something more complex in the body you can pass a snippet or child
+      component.
+    </p>
+    <p class="pb-6">
+      In this example a chart is passed in as a child component.
+    </p>
+    <Card
+      headerIsLink={true}
+      headerText="Adult social care quality"
+      onlyTextInBody={false}
+      ><PositionChart
         value="4.5"
         min="0"
         max="10"
@@ -117,55 +188,10 @@
       <p class="pt-4 pl-3">East Sussex: around average.</p></Card
     >
   </div>
-  <CodeBlock code={codeBlocks.codeBlock2} language="svelte"></CodeBlock>
+  <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
 {/snippet}
 
-{#snippet Example3()}
-  <div class="p-5 bg-white">
-    <Card
-      headerIsLink={false}
-      onlyTextInBody={true}
-      bodyText="The interaction in the card header is a search component instead of a link."
-      {headerSnippet}
-    ></Card>
-  </div>
-  <CodeBlock code={codeBlocks.codeBlock3} language="svelte"></CodeBlock>
-{/snippet}
-
-{#snippet headerSnippet()}
-  <PostcodeOrAreaSearch
-    hint=""
-    label_text="Search for a postcode"
-    label_size="m"
-    placeholder="e.g. NG8 5GT"
-    margin_bottom="2"
-    autoFocusSubmitOnSelection={true}
-    hideHint={false}
-    autoselect={false}
-    customPlacesData={[]}
-    customSourceSelector={() => "api"}
-    minLength={3}
-    label_id="postcode-search"
-    wrap_label_in_a_heading={true}
-  ></PostcodeOrAreaSearch>{/snippet}
-
-{#snippet Example4()}
-  <div class="p-5 bg-white">
-    <Card
-      headerIsLink={true}
-      headerText="Download local outcomes data"
-      onlyTextInBody={false}
-    >
-      <p>
-        Download the complete, latest Local Government Outcomes Framework data.
-        Alternatively <a href="">search for an area</a> and download what you need
-      </p></Card
-    >
-  </div>
-  <CodeBlock code={codeBlocks.codeBlock4} language="svelte"></CodeBlock>
-{/snippet}
-
-{#snippet Example5()}
+<!-- {#snippet Example5()}
   <div class="p-5 bg-white">
     {#each [1, 2, 3] as number}
       <Card
@@ -177,17 +203,4 @@
       >
     {/each}
   </div>
-{/snippet} -->
-
-<!-- {#snippet Example6()}
-  <div class="p-5 bg-white">
-    <Card
-      linkCard={false}
-      linkText="Adult social care quality"
-      onlyTextInBody={false}
-      ><PositionChart value="4.5" min="0" max="10"></PositionChart>
-      <PostcodeOrAreaSearch></PostcodeOrAreaSearch></Card
-    >
-  </div>
-  <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
 {/snippet} -->

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -7,6 +7,8 @@
   import Card from "$lib/components/ui/Card.svelte";
   import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
   import PostcodeOrAreaSearch from "$lib/components/ui/PostcodeOrAreaSearch.svelte";
+  import InsetText from "$lib/components/content/InsetText.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
 
   let accordionSnippetSections = [
     {
@@ -37,12 +39,12 @@
         "5. Example 5 - a card with a chart in the body using the children method",
       content: Example5,
     },
-    // {
-    //   id: "6",
-    //   heading:
-    //     "6. Example 6 - a card with non-standard content in header and body",
-    //   content: Example6,
-    // },
+    {
+      id: "6",
+      heading:
+        "6. Example 6 - a card with non-standard content in the header and body",
+      content: Example6,
+    },
     // {
     //   id: "7",
     //   heading: "7. Example 7 - multiple cards in a grid with dynamic props",
@@ -136,8 +138,8 @@
 {#snippet Example4()}
   <div class="p-5 bg-white">
     <p>
-      If you something more complex in the body you can pass a snippet or child
-      component.
+      If you want something more complex in the body you can pass a snippet or a
+      child component.
     </p>
     <p class="pb-6">
       In this example a chart is passed in using the snippet method.
@@ -167,8 +169,8 @@
 {#snippet Example5()}
   <div class="p-5 bg-white">
     <p>
-      If you something more complex in the body you can pass a snippet or child
-      component.
+      If you want something more complex in the body you can pass a snippet or a
+      child component.
     </p>
     <p class="pb-6">
       In this example a chart is passed in as a child component.
@@ -189,6 +191,30 @@
     >
   </div>
   <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet Example6()}
+  <div class="p-5 bg-white">
+    <p>
+      If you something more complex in the body you can pass a snippet or child
+      component.
+    </p>
+    <p class="pb-6">
+      In this example a chart is passed in as a child component.
+    </p>
+    <Card
+      headerIsLink={false}
+      headerText="Adult social care quality"
+      onlyTextInBody={false}
+      headerSnippet={headerSnippet2}
+      ><InsetText></InsetText>
+    </Card>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock5} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet headerSnippet2()}
+  <Button buttonType="default" textContent="Click me"></Button>
 {/snippet}
 
 <!-- {#snippet Example5()}

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -4,13 +4,20 @@
   import CodeBlock from "$lib/package-wrapping/CodeBlock.svelte";
   import * as codeBlocks from "./codeBlocks.js";
 
-import Card from "$lib/components/ui/Card.svelte";
+  import Card from "$lib/components/ui/Card.svelte";
+
+  import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
 
   let accordionSnippetSections = [
     {
       id: "1",
-      heading: "1. Example 1 - describe the use case here",
+      heading: "1. Example 1 - simple card with heading link, and body text",
       content: Example1,
+    },
+    {
+      id: "2",
+      heading: "2. Example 2 - card with a chart",
+      content: Example2,
     },
   ];
 </script>
@@ -37,32 +44,27 @@ import Card from "$lib/components/ui/Card.svelte";
 
 {#snippet Example1()}
   <div class="p-5 bg-white">
-    <Template
-      componentNameProp="Example 1"
-      checkboxProp={true}
-      dropdownProp="Dragonfruit"
-      jsObjectProp={[
-        {
-          name: "Borussia Dortmund",
-          country: "Germany",
-          color: "#fdff7d",
-        },
-        { name: "Liverpool FC", country: "UK", color: "#f59fad" },
-        {
-          name: "SSC Napoli",
-          country: "Italy",
-          color: "#69bfff",
-        },
-        {
-          name: "S.L. Benfica",
-          country: "Portugal",
-          color: "#ff8c96",
-        },
-      ]}
-      functionProp={function () {
-        window.alert(`Example 1 functionProp has been triggered.`);
-      }}
-    ></Template>
+    <Card
+      linkCard={true}
+      linkText="Card heading"
+      bodyText="Text in the body of the card"
+    ></Card>
   </div>
   <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet Example2()}
+  <div class="p-5 bg-white">
+    <Card
+      linkCard={true}
+      linkText="Adult social care quality"
+      onlyTextInBody={false}
+      {cardBottomSnippet}
+    ></Card>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+{/snippet}
+
+{#snippet cardBottomSnippet()}
+  <PositionChart></PositionChart>
 {/snippet}

--- a/src/wrappers/components/ui/card/Examples.svelte
+++ b/src/wrappers/components/ui/card/Examples.svelte
@@ -11,35 +11,35 @@
   let accordionSnippetSections = [
     {
       id: "1",
-      heading: "1. Example 1 - a simple card with heading link, and body text",
+      heading:
+        "1. Example 1 - a simple card with a link in the header and plain text in the body",
       content: Example1,
     },
     {
       id: "2",
-      heading: "2. Example 2 - a card with a chart in the body",
+      heading: "2. Example 2 - a card with different colors",
       content: Example2,
     },
-    {
-      id: "3",
-      heading:
-        "3. Example 3 - a card with a search component instead of a heading link",
-      content: Example3,
-    },
-    {
-      id: "4",
-      heading: "4. Example 4 - a card with a link in the body",
-      content: Example4,
-    },
-    {
-      id: "5",
-      heading: "5. Example 5 - multiple cards",
-      content: Example5,
-    },
     // {
-    //   id: "6",
-    //   heading: "6. Example 6 - render children in top and bottom",
-    //   content: Example6,
+    //   id: "2",
+    //   heading: "2. Example 2 - a card with a chart in the body",
+    //   content: Example2,
     // },
+    // {
+    //   id: "3",
+    //   heading:
+    //     "3. Example 3 - a card with a search component instead of a heading link",
+    //   content: Example3,
+    // },
+    // {
+    //   id: "4",
+    //   heading: "4. Example 4 - a card with a link in the body",
+    //   content: Example4,
+    // },
+    // {
+    //   id: "5",
+    //   heading: "5. Example 5 - multiple cards",
+    //   content: Example5,
   ];
 </script>
 
@@ -67,12 +67,15 @@
   <div class="p-5 bg-white">
     <p>
       This is the default card. If you don't pass any snippets or childen into
-      the component you get this. headingIsLink and onlyTextInBody are set to
-      true by default.
+      the component you get this.
+    </p>
+    <p class="pb-6">
+      headerIsLink and onlyTextInBody are set to their default values of true.
     </p>
     <Card
       headerIsLink={true}
-      linkText="Card heading"
+      headerText="Card heading"
+      onlyTextInBody={true}
       bodyText="Text in the body of the card"
     ></Card>
   </div>
@@ -81,9 +84,26 @@
 
 {#snippet Example2()}
   <div class="p-5 bg-white">
+    <p class="pb-6">
+      A card with different colors for the text, background and borders.
+    </p>
+    <Card
+      headerTextColor="black"
+      headerBackgroundColor="lightblue"
+      bodyTextColor="grey"
+      bodyBackgroundColor="lightgreen"
+      bodyBottomBorderColor="red"
+      bodyTopBorderColor="purple"
+    ></Card>
+  </div>
+  <CodeBlock code={codeBlocks.codeBlock1} language="svelte"></CodeBlock>
+{/snippet}
+
+<!-- {#snippet Example2()}
+  <div class="p-5 bg-white">
     <Card
       headerIsLink={true}
-      linkText="Adult social care quality"
+      headerText="Adult social care quality"
       onlyTextInBody={false}
     >
       <PositionChart
@@ -133,7 +153,7 @@
   <div class="p-5 bg-white">
     <Card
       headerIsLink={true}
-      linkText="Download local outcomes data"
+      headerText="Download local outcomes data"
       onlyTextInBody={false}
     >
       <p>
@@ -150,14 +170,14 @@
     {#each [1, 2, 3] as number}
       <Card
         headerIsLink={true}
-        linkText="Adult social care quality"
+        headerText="Adult social care quality"
         onlyTextInBody={false}
         ><PositionChart value={number} min="0" max="10"></PositionChart>
         <p>some text</p></Card
       >
     {/each}
   </div>
-{/snippet}
+{/snippet} -->
 
 <!-- {#snippet Example6()}
   <div class="p-5 bg-white">

--- a/src/wrappers/components/ui/card/codeBlocks.js
+++ b/src/wrappers/components/ui/card/codeBlocks.js
@@ -10,3 +10,84 @@ export const codeBlock1 = `
       linkText="Card heading"
       bodyText="Text in the body of the card"
     ></Card>`;
+
+export const codeBlock2 = `
+<script>
+
+  import Card from "$lib/components/ui/Card.svelte";
+  import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
+
+</script>
+
+    <Card
+      linkCard={true}
+      linkText="Adult social care quality"
+      onlyTextInBody={false}
+      cardBottomSnippet={cardBottomSnippet1}
+    ></Card>
+    
+    {#snippet cardBottomSnippet1()}
+      <PositionChart
+        value="4.5"
+        min="0"
+        max="10"
+        annotation="East Sussex"
+        showAxis={false}
+        chartHeight={30}
+      ></PositionChart>
+      <p class="pt-4 pl-3">East Sussex: around average.</p>
+    {/snippet}`;
+
+export const codeBlock3 = `
+<script>
+
+  import Card from "$lib/components/ui/Card.svelte";
+  import PostcodeOrAreaSearch from "$lib/components/ui/PostcodeOrAreaSearch.svelte";
+
+</script>
+
+    <Card
+      linkCard={false}
+      onlyTextInBody={true}
+      bodyText="The interaction in the card header is a search component instead of a link."
+      {cardTopSnippet}
+    ></Card>
+    
+    {#snippet cardTopSnippet()}
+      <PostcodeOrAreaSearch
+        hint=""
+        label_text="Search for a postcode"
+        label_size="m"
+        placeholder="e.g. NG8 5GT"
+        margin_bottom="2"
+        autoFocusSubmitOnSelection={true}
+        hideHint={false}
+        autoselect={false}
+        customPlacesData={[]}
+        customSourceSelector={() => "api"}
+        minLength={3}
+        label_id="postcode-search"
+        wrap_label_in_a_heading={true}
+      ></PostcodeOrAreaSearch>
+    {/snippet}`;
+
+export const codeBlock4 = `
+<script>
+
+  import Card from "$lib/components/ui/Card.svelte";
+
+</script>
+
+    <Card
+      linkCard={true}
+      linkText="Download local outcomes data"
+      onlyTextInBody={false}
+      cardBottomSnippet={cardBottomSnippet2}
+    ></Card>
+    
+    {#snippet cardBottomSnippet2()}
+      <p>
+        Download the complete, latest Local Government Outcomes Framework data.
+        Alternatively <a href="">search for an area</a> and download what you need
+      </p>
+    {/snippet}`;

--- a/src/wrappers/components/ui/card/codeBlocks.js
+++ b/src/wrappers/components/ui/card/codeBlocks.js
@@ -94,3 +94,27 @@ export const codeBlock5 = `
 ></PositionChart>
 <p class="pt-4 pl-3">East Sussex: around average.</p>
 </Card>`;
+
+export const codeBlock6 = `
+<script>
+  import Card from "$lib/components/ui/Card.svelte";
+  import PostcodeOrAreaSearch from "$lib/components/ui/PostcodeOrAreaSearch.svelte";
+</script>
+
+<Card
+  headerIsLink={false}
+  headerText="Adult social care quality"
+  onlyTextInBody={false}
+  headerSnippet={headerSnippet2}
+  ><p>Some text with a <a href="">link</a></p>
+</Card>
+
+{#snippet headerSnippet2()}
+  <PostcodeOrAreaSearch
+    label_text="Search for a postcode"
+    placeholder="e.g. NG8 5GT"
+    margin_bottom="2"
+    customPlacesData={[]}
+    customSourceSelector={() => "api"}
+  ></PostcodeOrAreaSearch>
+{/snippet}`;

--- a/src/wrappers/components/ui/card/codeBlocks.js
+++ b/src/wrappers/components/ui/card/codeBlocks.js
@@ -118,3 +118,28 @@ export const codeBlock6 = `
     customSourceSelector={() => "api"}
   ></PostcodeOrAreaSearch>
 {/snippet}`;
+
+export const codeBlock7 = `
+<script>
+  import Card from "$lib/components/ui/Card.svelte";
+  import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
+</script>
+
+{#each metrics as { metric, value }}
+  <Card
+    headerIsLink={true}
+    headerText={metric}
+    onlyTextInBody={false}
+    headerTextSize="1.25rem"
+    ><PositionChart {value} min="0" max="10" chartHeight="20"
+    ></PositionChart>
+  </Card>
+{/each}
+
+<style>
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+</style>`;

--- a/src/wrappers/components/ui/card/codeBlocks.js
+++ b/src/wrappers/components/ui/card/codeBlocks.js
@@ -1,32 +1,12 @@
 export const codeBlock1 = `
 <script>
 
-  import Template from "$lib/package-wrapping/Template.svelte";
+  import Card from "$lib/components/ui/Card.svelte";
 
 </script>
 
-<Template
-checkboxProp={true}
-dropdownProp="Dragonfruit"
-jsObjectProp={[
-  {
-    name: "Borussia Dortmund",
-    country: "Germany",
-    color: "#fdff7d",
-  },
-  { name: "Liverpool FC", country: "UK", color: "#f59fad" },
-  {
-    name: "SSC Napoli",
-    country: "Italy",
-    color: "#69bfff",
-  },
-  {
-    name: "S.L. Benfica",
-    country: "Portugal",
-    color: "#ff8c96",
-  },
-]}
-functionProp={function (event, pokemon) {
-  window.alert("Example 1 functionProp has been triggered.");
-}}
-></Template>`;
+    <Card
+      linkCard={true}
+      linkText="Card heading"
+      bodyText="Text in the body of the card"
+    ></Card>`;

--- a/src/wrappers/components/ui/card/codeBlocks.js
+++ b/src/wrappers/components/ui/card/codeBlocks.js
@@ -1,93 +1,96 @@
 export const codeBlock1 = `
 <script>
-
   import Card from "$lib/components/ui/Card.svelte";
-
 </script>
 
-    <Card
-      linkCard={true}
-      linkText="Card heading"
-      bodyText="Text in the body of the card"
-    ></Card>`;
+<Card
+  headerIsLink={true}
+  headerText="Card heading"
+  onlyTextInBody={true}
+  bodyText="Text in the body of the card"
+></Card>`;
 
 export const codeBlock2 = `
 <script>
-
   import Card from "$lib/components/ui/Card.svelte";
-  import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
-
 </script>
 
-    <Card
-      linkCard={true}
-      linkText="Adult social care quality"
-      onlyTextInBody={false}
-      cardBottomSnippet={cardBottomSnippet1}
-    ></Card>
-    
-    {#snippet cardBottomSnippet1()}
-      <PositionChart
-        value="4.5"
-        min="0"
-        max="10"
-        annotation="East Sussex"
-        showAxis={false}
-        chartHeight={30}
-      ></PositionChart>
-      <p class="pt-4 pl-3">East Sussex: around average.</p>
-    {/snippet}`;
+<Card
+  headerTextColor="black"
+  headerBackgroundColor="lightblue"
+  bodyTextColor="grey"
+  bodyBackgroundColor="lightgreen"
+  bodyBottomBorderColor="red"
+  bodyTopBorderColor="purple"
+></Card>`;
 
 export const codeBlock3 = `
 <script>
-
   import Card from "$lib/components/ui/Card.svelte";
   import PostcodeOrAreaSearch from "$lib/components/ui/PostcodeOrAreaSearch.svelte";
-
 </script>
 
-    <Card
-      linkCard={false}
-      onlyTextInBody={true}
-      bodyText="The interaction in the card header is a search component instead of a link."
-      {cardTopSnippet}
-    ></Card>
+<Card
+  headerIsLink={false}
+  onlyTextInBody={true}
+  bodyText="Enter your postcode to find out about deprivation in your local area."
+  {headerSnippet}
+></Card>
     
-    {#snippet cardTopSnippet()}
-      <PostcodeOrAreaSearch
-        hint=""
-        label_text="Search for a postcode"
-        label_size="m"
-        placeholder="e.g. NG8 5GT"
-        margin_bottom="2"
-        autoFocusSubmitOnSelection={true}
-        hideHint={false}
-        autoselect={false}
-        customPlacesData={[]}
-        customSourceSelector={() => "api"}
-        minLength={3}
-        label_id="postcode-search"
-        wrap_label_in_a_heading={true}
-      ></PostcodeOrAreaSearch>
-    {/snippet}`;
+{#snippet headerSnippet()}
+  <PostcodeOrAreaSearch
+    label_text="Search for a postcode"
+    placeholder="e.g. NG8 5GT"
+    margin_bottom="2"
+    customPlacesData={[]}
+    customSourceSelector={() => "api"}
+  ></PostcodeOrAreaSearch>
+{/snippet}`;
 
 export const codeBlock4 = `
 <script>
-
   import Card from "$lib/components/ui/Card.svelte";
-
+  import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
 </script>
 
-    <Card
-      linkCard={true}
-      linkText="Download local outcomes data"
-      onlyTextInBody={false}
-      cardBottomSnippet={cardBottomSnippet2}
-    ></Card>
+<Card
+  headerIsLink={true}
+  headerText="Adult social care quality"
+  onlyTextInBody={false}
+  {bodySnippet}
+></Card>
     
-    {#snippet cardBottomSnippet2()}
-      <p>
-        Download the complete, latest Local Government Outcomes Framework data.
-        Alternatively <a href="">search for an area</a> and download what you need
-      </p>
-    {/snippet}`;
+{#snippet bodySnippet()}
+  <PositionChart
+    value="4.5"
+    min="0"
+    max="10"
+    annotation="East Sussex"
+    showAxis={false}
+    chartHeight={30}
+  ></PositionChart>
+  <p class="pt-4 pl-3">East Sussex: around average.</p>
+{/snippet}`;
+
+export const codeBlock5 = `
+<script>
+  import Card from "$lib/components/ui/Card.svelte";
+  import PositionChart from "$lib/components/data-vis/position-chart/PositionChart.svelte";
+</script>
+
+<Card
+  headerIsLink={true}
+  headerText="Adult social care quality"
+  onlyTextInBody={false}
+  {bodySnippet}
+>
+<PositionChart
+  value="4.5"
+  min="0"
+  max="10"
+  annotation="East Sussex"
+  showAxis={false}
+  chartHeight={30}
+></PositionChart>
+<p class="pt-4 pl-3">East Sussex: around average.</p>
+</Card>`;


### PR DESCRIPTION
I made some improvements to the card component.

It's nearly ready for use in LOF. The main thing left is to find a way to get the card headers and charts aligned when called in a grid context like in the LOF summary page. Other fixes may emerge when it comes to using it in LOF.

What did I do in this PR?
- I made the card header its own component (the heading and chevron). Whilst doing that I improved its structure. This fixed the issue with the chevron growing and shrinking.
- Now the header and body sections of the card can accept snippets.
- The body section can also accept child components as an alternative method for embedding more complex content. This method is used for the grid of cards case where a value needs to be passed down through each card to its chart.
- I added Examples to the component wrapper page in the component library which explain how to use it.