### PR TITLE
Replace color interpolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/dompurify": "^3.0.5",
         "accessible-autocomplete": "^3.0.1",
         "choices.js": "^11.1.0",
+        "chroma-js": "^3.2.0",
         "csv-parser": "^3.0.0",
         "d3": "^7.9.0",
         "decimal.js": "^10.5.0",
@@ -2973,6 +2974,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chroma-js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/clsx": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@types/dompurify": "^3.0.5",
     "accessible-autocomplete": "^3.0.1",
     "choices.js": "^11.1.0",
+    "chroma-js": "^3.2.0",
     "csv-parser": "^3.0.0",
     "d3": "^7.9.0",
     "decimal.js": "^10.5.0",

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -1,5 +1,6 @@
 <script>
   import { scaleLinear } from "d3-scale";
+  import chroma from "chroma-js";
   import PositionChartAxis from "./PositionChartAxis.svelte";
   import ValueLabel from "../line-chart/ValueLabel.svelte";
   import Button from "../../ui/Button.svelte";
@@ -80,6 +81,7 @@
       activeMarkerId = null;
     },
     activeMarkerId = undefined,
+    distribution = undefined,
   } = $props();
 
   let xTicks = $state([]);
@@ -156,73 +158,11 @@
   const range = $derived(Array.from({ length: nSegments }, (_, i) => i));
 
   function interpolateColors(hex1, hex2, steps, hexMid = null) {
-    // Convert hex to RGB
-    const hexToRgb = (hex) => {
-      hex = hex.replace(/^#/, "");
-      if (hex.length === 3) {
-        hex = hex
-          .split("")
-          .map((x) => x + x)
-          .join("");
-      }
-      const bigint = parseInt(hex, 16);
-      return {
-        r: (bigint >> 16) & 255,
-        g: (bigint >> 8) & 255,
-        b: bigint & 255,
-      };
-    };
-    // Convert RGB to hex
-    const rgbToHex = ({ r, g, b }) =>
-      "#" +
-      [r, g, b]
-        .map((x) => {
-          const hex = x.toString(16);
-          return hex.length === 1 ? "0" + hex : hex;
-        })
-        .join("");
-    // Helper: interpolate between two colors
-    const interpolate = (start, end, count) => {
-      const arr = [];
-      for (let i = 0; i < count; i++) {
-        const t = i / (count - 1);
-        const r = Math.round(start.r + (end.r - start.r) * t);
-        const g = Math.round(start.g + (end.g - start.g) * t);
-        const b = Math.round(start.b + (end.b - start.b) * t);
-        arr.push({ r, g, b });
-      }
-      return arr;
-    };
-    const start = hexToRgb(hex1);
-    const end = hexToRgb(hex2);
-    // Case 1: just two colors
-    if (!hexMid) {
-      return interpolate(start, end, steps).map(rgbToHex);
-    }
-    // Case 2: three colors
-    const mid = hexToRgb(hexMid);
-    const result = [];
-    if (steps % 2 === 1) {
-      // Odd steps → midpoint included
-      const half = (steps - 1) / 2;
-      const firstHalf = interpolate(start, mid, half + 1); // includes mid
-      const secondHalf = interpolate(mid, end, half + 1); // includes mid again
-      result.push(
-        ...firstHalf.slice(0, -1).map(rgbToHex), // drop duplicate mid
-        ...secondHalf.map(rgbToHex),
-      );
-    } else {
-      // Even steps → midpoint excluded
-      const half = steps / 2;
-      const firstHalf = interpolate(start, mid, half + 1); // includes mid
-      const secondHalf = interpolate(mid, end, half + 1); // includes mid again
-      result.push(
-        ...firstHalf.slice(0, -1).map(rgbToHex), // drop mid
-        ...secondHalf.slice(1).map(rgbToHex), // drop mid
-      );
-    }
-    return result;
+    return chroma.scale([hex1, hexMid, hex2]).colors(steps);
   }
+  let interpolatedColors = $derived(
+    interpolateColors(startColor, endColor, nSegments, midColor),
+  );
 
   // the 'bar' is the 10 rectangles side by side
   let barWidth = $derived(chartWidth - markerRadius * 2);
@@ -353,9 +293,7 @@
               height={barHeight}
               fill={colorScale && colorScale.length > 0
                 ? colorScale[number]
-                : interpolateColors(startColor, endColor, nSegments, midColor)[
-                    number
-                  ]}
+                : interpolatedColors[number]}
             ></rect></g
           >{/each}
         {#each Object.entries(positionChart.rowData) as [tier, points]}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -157,8 +157,9 @@
 
   const range = $derived(Array.from({ length: nSegments }, (_, i) => i));
 
-  function interpolateColors(hex1, hex2, steps, hexMid = null) {
-    return chroma.scale([hex1, hexMid, hex2]).colors(steps);
+  function interpolateColors(startColor, endColor, nSegments, midColor = null) {
+    let colorArray = [startColor, midColor, endColor].filter(Boolean);
+    return chroma.scale(colorArray).colors(nSegments);
   }
   let interpolatedColors = $derived(
     interpolateColors(startColor, endColor, nSegments, midColor),

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -341,19 +341,20 @@
             {/if}
           {/each}
         {/each}
-
-        <Axis
-          bind:ticksArray={xTicks}
-          {chartHeight}
-          chartWidth={chartWidth - markerRadius * 2}
-          orientation={{ axis: "x", position: "bottom" }}
-          range={[markerRadius, chartWidth - markerRadius]}
-          domain={[xTickMin, xTickMax]}
-          values={[0, 2, 3, 4]}
-          fontSize={14}
-          floor={min}
-          ceiling={max}
-        ></Axis>
+        {#if showAxis}
+          <Axis
+            bind:ticksArray={xTicks}
+            {chartHeight}
+            chartWidth={chartWidth - markerRadius * 2}
+            orientation={{ axis: "x", position: "bottom" }}
+            range={[markerRadius, chartWidth - markerRadius]}
+            domain={[xTickMin, xTickMax]}
+            values={[0, 2, 3, 4]}
+            fontSize={14}
+            floor={min}
+            ceiling={max}
+          ></Axis>
+        {/if}
       </svg>
     </div>
     {#if moreInfoTogglesArray[i]}


### PR DESCRIPTION
- We previously had a long custom function for interpolating between hex codes to create custom colour scales
- This PR replaces that with the same functionality provided by [chroma.js](https://gka.github.io/chroma.js/)
- The package has good security according to https://socket.dev/npm/package/chroma-js
- To test: `npm run dev` to launch the component library. Go to PositionChart. Replace the `colorScale` array with an empty array. Change the hex codes in `startColor`, `endColor`, `midColor` to verify that the color scale changes
- Another small fix: wrapping the Axis component with `showAxis` to control visibility
