### PR TITLE
Set axis limits using min and max 

### DIFF
--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -22,7 +22,8 @@
     ticksArray = $bindable<number[]>([]),
 
     // Values to derive ticks/domain from if ticksArray not provided
-    values = undefined as number[] | undefined,
+    min = undefined as number | undefined,
+    max = undefined as number | undefined,
 
     orientation = { axis: "x", position: "bottom" } as Orientation,
 
@@ -50,7 +51,9 @@
     chartWidth?: number;
     numberOfTicks?: number;
     ticksArray?: number[];
-    values?: number[];
+    min?: number;
+    max?: number;
+
     orientation?: Orientation;
     floor?: number;
     ceiling?: number;
@@ -72,7 +75,8 @@
   const innerHeight = $derived(Math.max(0, chartHeight));
 
   function computeDefaultDomain(): [number, number] {
-    const arr = (ticksArray && ticksArray.length ? ticksArray : values) ?? [];
+    const arr =
+      (ticksArray && ticksArray.length ? ticksArray : [min, max]) ?? [];
     const dMin =
       floor ?? (arr.length ? arr.reduce((a, b) => (a < b ? a : b)) : 0);
     const dMax =
@@ -118,14 +122,15 @@
     stroke="black"
     stroke-width="2px"
   ></line>
-  {#if values}
+  {#if ticksArray || (min && max)}
     {#key numberOfTicks}
       <Ticks
         bind:ticksArray
         {chartWidth}
         {chartHeight}
         {axisFunction}
-        {values}
+        {min}
+        {max}
         {numberOfTicks}
         {orientation}
         {floor}

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -16,7 +16,8 @@
     chartWidth,
     chartHeight,
     axisFunction,
-    values,
+    min,
+    max,
     numberOfTicks,
     floor,
     ceiling,
@@ -28,12 +29,12 @@
     chartWidth: number;
     chartHeight: number;
     axisFunction: any;
-    values: number[]; // numeric array for domain
+    min: number;
+    max: number;
     numberOfTicks?: number;
     floor?: number;
     ceiling?: number;
     orientation: Orientation;
-    /** Mandatory custom label generator */
     labelFormatter?: (tick: number, index: number) => string;
     fontSize?: number;
   } = $props();
@@ -52,23 +53,21 @@
   }
 
   function generateTicks(
-    data: number[],
+    min: number,
+    max: number,
     numTicks: number,
     floorVal?: number,
     ceilingVal?: number,
   ): number[] {
-    const minValueFromData = Decimal.min(...data);
-    const maxValueFromData = Decimal.max(...data);
-
     const minVal =
       floorVal !== undefined
-        ? Decimal.min(new Decimal(floorVal), minValueFromData)
-        : new Decimal(minValueFromData);
+        ? Decimal.min(new Decimal(floorVal), min)
+        : new Decimal(min);
 
     const maxVal =
       ceilingVal !== undefined
-        ? Decimal.max(new Decimal(ceilingVal), maxValueFromData)
-        : new Decimal(maxValueFromData);
+        ? Decimal.max(new Decimal(ceilingVal), max)
+        : new Decimal(max);
 
     const rangeVal = maxVal.minus(minVal);
     const roughStep = rangeVal.div(numTicks - 1);
@@ -125,7 +124,7 @@
 
   // Compute ticks
   numberOfTicks = tickCount(chartWidth, chartHeight);
-  const rawTicks = generateTicks(values, numberOfTicks, floor, ceiling);
+  const rawTicks = generateTicks(min, max, numberOfTicks, floor, ceiling);
 
   ticksArray = clampTickEnds(rawTicks, floor, ceiling);
 </script>

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -84,6 +84,8 @@
 
   let xTicks = $state([]);
 
+  $inspect({ xTicks });
+
   let xTickMin = $derived(xTicks.length ? Math.min(...xTicks) : 0);
   let xTickMax = $derived(xTicks.length ? Math.max(...xTicks) : 1);
 
@@ -403,19 +405,21 @@
             {/if}
           {/each}
         {/each}
-
-        <Axis
-          bind:ticksArray={xTicks}
-          {chartHeight}
-          chartWidth={chartWidth - markerRadius * 2}
-          orientation={{ axis: "x", position: "bottom" }}
-          range={[markerRadius, chartWidth - markerRadius]}
-          domain={[xTickMin, xTickMax]}
-          values={[0, 2, 3, 4]}
-          fontSize={14}
-          floor={min}
-          ceiling={max}
-        ></Axis>
+        {#if showAxis}
+          <Axis
+            bind:ticksArray={xTicks}
+            {chartHeight}
+            chartWidth={chartWidth - markerRadius * 2}
+            orientation={{ axis: "x", position: "bottom" }}
+            range={[markerRadius, chartWidth - markerRadius]}
+            domain={[xTickMin, xTickMax]}
+            {min}
+            {max}
+            fontSize={14}
+            floor={min}
+            ceiling={max}
+          ></Axis>
+        {/if}
       </svg>
     </div>
     {#if moreInfoTogglesArray[i]}


### PR DESCRIPTION
- Axis and Ticks components were expecting a 'values' prop containing the distribution of values.
- This seems unnecessary as we only needed to extract the min and the max from this array.
- Instead, pass in `min` and `max `directly.
- This PR also removes hard-coded `values=[0,2,3,4]` which was causing axes not to respect `min` and `max` supplied by PositionChart
