### PR TITLE
Improve use of floor and ceiling in axes

### DIFF
--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -59,20 +59,17 @@
     floorVal?: number,
     ceilingVal?: number,
   ): number[] {
-    const minVal =
-      floorVal !== undefined
-        ? Decimal.min(new Decimal(floorVal), min)
-        : new Decimal(min);
+    let minVal =
+      floorVal !== undefined ? new Decimal(floorVal) : new Decimal(min);
 
-    const maxVal =
-      ceilingVal !== undefined
-        ? Decimal.max(new Decimal(ceilingVal), max)
-        : new Decimal(max);
+    let maxVal =
+      ceilingVal !== undefined ? new Decimal(ceilingVal) : new Decimal(max);
 
     const rangeVal = maxVal.minus(minVal);
     const roughStep = rangeVal.div(numTicks - 1);
-    const normalizedSteps = [1, 2, 5, 10];
-
+    const normalizedSteps = [
+      1, 2, 2.5, 3, 4, 5, 6, 8, 10, 12, 15, 25, 30, 35, 40, 45,
+    ];
     const stepPower = Decimal.pow(
       10,
       -Math.floor(Math.log10(roughStep.toNumber())),
@@ -123,10 +120,14 @@
   }
 
   // Compute ticks
-  numberOfTicks = tickCount(chartWidth, chartHeight);
-  const rawTicks = generateTicks(min, max, numberOfTicks, floor, ceiling);
+  let computedTickCount = $derived(
+    numberOfTicks ?? tickCount(chartWidth, chartHeight),
+  );
 
-  ticksArray = clampTickEnds(rawTicks, floor, ceiling);
+  let rawTicks = $derived(
+    generateTicks(min, max, computedTickCount, floor, ceiling),
+  );
+  ticksArray = rawTicks;
 </script>
 
 {#if axisFunction && ticksArray && orientation.axis && orientation.position}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -82,6 +82,8 @@
     },
     activeMarkerId = undefined,
     distribution = undefined,
+    floor = undefined,
+    ceiling = undefined,
   } = $props();
 
   let xTicks = $state([]);
@@ -355,8 +357,8 @@
             {min}
             {max}
             fontSize={14}
-            floor={min}
-            ceiling={max}
+            {floor}
+            {ceiling}
           ></Axis>
         {/if}
       </svg>


### PR DESCRIPTION
Previously, floor and ceiling were only used under certain conditions. For example, `floor < min` or `ceiling > max`.

This PR changes this so they are used whenever they are provided. This means:
- floor can now be higher or lower than min
- ceiling can now be higher or lower than max.

This removes the need for `clamp()` since these variables are respected by the `generateTicks()` function