### PR TITLE
Temporary fix for chart arrow placement

### DIFF
--- a/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
@@ -58,7 +58,6 @@
   .left-label,
   .right-label {
     display: flex;
-    width: 45%;
   }
 
   .left-label {

--- a/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
@@ -58,6 +58,7 @@
   .left-label,
   .right-label {
     display: flex;
+    max-width: 120px;
   }
 
   .left-label {


### PR DESCRIPTION
Width: 45% looked fine on narrow charts, but on wider charts, the final axis tick didn't reach the end. Need to ensure flex spacing is more robust.