### PR TITLE
Resolve chart layout issues

### DIFF
--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -362,7 +362,7 @@
       style="height:{chartHeight +
         (showAxis ? 30 : 30) +
         (showArrows ? 30 : 0) +
-        (showAverage ? 30 : 0)}px"
+        (showAverage ? 40 : 0)}px"
       bind:clientWidth={chartWidth}
     >
       <svg

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -67,6 +67,7 @@
 <style>
   .card {
     flex-direction: column;
+    min-width: 0;
   }
 
   .header-div {


### PR DESCRIPTION
- Give average label more space to prevent overlap with arrows
- `min-width: 0` allows cards to shrink