### PR TITLE
Solid fill option for histogram bars

### DIFF
--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -19,6 +19,7 @@
     endColor = "#2D6644",
     floor = undefined,
     ceiling = undefined,
+    fill = "grey",
     nBins = 10,
     padding = 0,
     height = 50,
@@ -34,7 +35,9 @@
     skew = true,
     showGridlines = true,
     showTickMarks = false,
-    strokeWidth = 0.25,
+    tickStrokeWidth = 0.25,
+    barStrokeWidth = 0,
+    barStrokeColor = "white",
   } = $props();
 
   let xTicks = $state([]);
@@ -198,7 +201,7 @@
                 numberOfTicks={4}
                 {showGridlines}
                 {showTickMarks}
-                strokeWidth={0.25}
+                strokeWidth={tickStrokeWidth}
               ></Axis>
             {/if}
           </g>
@@ -209,8 +212,9 @@
                 y={height - yScale(bin.length)}
                 width={Math.abs(xScale(bin.x1) - xScale(bin.x0))}
                 height={yScale(bin.length)}
-                fill={colorScale[i]}
-                stroke-width={0}
+                fill={fill ?? colorScale[i]}
+                stroke-width={barStrokeWidth}
+                stroke={barStrokeColor}
               ></rect>
             {/key}
           {/each}

--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -72,6 +72,7 @@
 
   .header-div {
     padding: 20px;
+    flex: 1;
   }
 
   .body-div {


### PR DESCRIPTION
- pass a single colour to Histogram via 'fill' and it will be rendered. If no fill, interpolated or custom colour scale will be used
- Option for solid stroke around the bars - but this is problematic as the stroke encroaches on the bar itself, changing the value plotted. There is no `outer-fill` so we'll need another solution - likely rendering a bar behind in the stroke colour and a smaller bar infront.
- flex:1 on card header for sharing height across rows 