### PR TITLE
Include outliers in histogram by clamping

### DIFF
--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -38,6 +38,7 @@
     tickStrokeWidth = 0.25,
     barStrokeWidth = 0,
     barStrokeColor = "white",
+    includeOutliers = true,
   } = $props();
 
   let xTicks = $state([]);
@@ -74,11 +75,18 @@
   const binner = $derived(
     bin().domain([domainXMin, domainXMax]).thresholds(binThresholds),
   );
+  const clampedDistribution = $derived(
+    distribution.map((d) => Math.min(Math.max(d, domainXMin), domainXMax)),
+  );
+
+  const binnedDistribution = $derived(
+    binner(includeOutliers ? clampedDistribution : distribution),
+  );
 
   const bins = $derived(
     polarity === "reverse"
-      ? binner(distribution).toReversed()
-      : binner(distribution),
+      ? binnedDistribution.toReversed()
+      : binnedDistribution,
   );
 
   const proportionsInBins = $derived(


### PR DESCRIPTION
d3's bin function doesn't include values beyond the domain. 

This PR includes outliers in the histogram's extreme bins, when `includeOutliers` is `true`. This should be used in conjunction with the Axis component's `labelFormatter` to add `<` and `>` to the extreme ticks.

It works by clamping the distribution of values that's passed to the `binner` function.

Clamping changes the values passed to the function, so the original values don't exist in the bin. This is fine when you just need the count, but could be an issue if there's a need to access the underlying data.

