### PR TITLE
Format axis ticks, refine chart layout

### DIFF
--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -38,6 +38,7 @@
     tickStrokeWidth = 0.25,
     barStrokeWidth = 0,
     barStrokeColor = "white",
+    topLabel = true,
   } = $props();
 
   let xTicks = $state([]);
@@ -138,24 +139,48 @@
   );
 
   $inspect({ colorScale });
+
+  const layout = $derived.by(() => {
+    let y = 0;
+
+    const topLabelY = topLabel ? y : null;
+    if (topLabel) y += 20;
+
+    const annotationY = annotationText ? y : null;
+    if (annotationText) y += 25;
+
+    const chartY = y;
+    y += height;
+
+    const xAxisY = showXAxis ? y : null;
+    if (showXAxis) y += 25;
+
+    return {
+      topLabelY,
+      annotationY,
+      chartY,
+      xAxisY,
+      totalHeight: y,
+    };
+  });
 </script>
 
 {#key containerWidth}
   <div class="scale-container" bind:clientWidth={containerWidth}>
-    <svg
-      width={containerWidth}
-      height={height + 20 + (annotationText ? 25 : 0) + (showXAxis ? 25 : 0)}
-      style="overflow: visible;"
-    >
-      <g transform="translate({padding / 2},0)">
-        <g transform="translate(0,{annotationText ? 25 : 20})">
-          <text dx={-2} dy={-4} fill="#666" font-size="0.75em"
-            >Number of areas</text
-          ></g
-        >
+    <svg width={containerWidth} height={layout.totalHeight}>
+      <g transform="translate({padding / 2}, 0)">
+        {#if topLabel && layout.topLabelY !== null}
+          <text x={0} y={layout.topLabelY + 14} fill="#666" font-size="0.75em">
+            Number of areas
+          </text>
+        {/if}
 
-        {#if annotationText}
-          <g transform="translate({xScale(annotationValue)},0)">
+        {#if annotationText && layout.annotationY !== null}
+          <g
+            transform="translate({xScale(
+              annotationValue,
+            )}, {layout.annotationY})"
+          >
             <text
               fill="#555555"
               font-size="0.8em"
@@ -168,43 +193,25 @@
           </g>
         {/if}
 
-        <g transform="translate(0,{annotationText ? 25 : 20})">
-          <g>
-            {#if showXAxis}
-              <Axis
-                bind:ticksArray={xTicks}
-                chartHeight={height}
-                chartWidth={containerWidth - padding}
-                orientation={{ axis: "x", position: "bottom" }}
-                domain={[xTickFirst, xTickLast]}
-                min={minX}
-                max={maxX}
-                range={useRange}
-                fontSize={13}
-                {floor}
-                {ceiling}
-                {labelFormatter}
-                {numberOfTicks}
-              ></Axis>
-            {/if}
-            {#if showYAxis}
-              <Axis
-                bind:ticksArray={yTicks}
-                chartHeight={height}
-                chartWidth={containerWidth - padding}
-                orientation={{ axis: "y", position: "left" }}
-                min={minY}
-                max={maxY}
-                domain={[0, yTickLast]}
-                range={[0, height]}
-                fontSize={0}
-                numberOfTicks={4}
-                {showGridlines}
-                {showTickMarks}
-                strokeWidth={tickStrokeWidth}
-              ></Axis>
-            {/if}
-          </g>
+        <g transform="translate(0, {layout.chartY})">
+          {#if showYAxis}
+            <Axis
+              bind:ticksArray={yTicks}
+              chartHeight={height}
+              chartWidth={containerWidth - padding}
+              orientation={{ axis: "y", position: "left" }}
+              min={minY}
+              max={maxY}
+              domain={[0, yTickLast]}
+              range={[0, height]}
+              fontSize={0}
+              numberOfTicks={4}
+              {showGridlines}
+              {showTickMarks}
+              strokeWidth={tickStrokeWidth}
+            />
+          {/if}
+
           {#each bins as bin, i}
             {#key bin.x0}
               <rect
@@ -219,6 +226,26 @@
             {/key}
           {/each}
         </g>
+
+        {#if showXAxis && layout.xAxisY !== null}
+          <g transform="translate(0, {layout.xAxisY})">
+            <Axis
+              bind:ticksArray={xTicks}
+              chartHeight={height}
+              chartWidth={containerWidth - padding}
+              orientation={{ axis: "x", position: "bottom" }}
+              domain={[xTickFirst, xTickLast]}
+              min={minX}
+              max={maxX}
+              range={useRange}
+              fontSize={13}
+              {floor}
+              {ceiling}
+              {labelFormatter}
+              {numberOfTicks}
+            />
+          </g>
+        {/if}
       </g>
     </svg>
   </div>

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -10,7 +10,12 @@
   type AxisPosition = "bottom" | "top" | "left" | "right";
   type Orientation = { axis: AxisName; position: AxisPosition };
   type AxisProjector = (value: number) => number;
-  type LabelFormatter = (tick: number, index: number) => string | number;
+  type LabelFormatter = (
+    tick: number,
+    index: number,
+    numberOfTicks: number,
+  ) => string | number;
+
   type Polarity = "standard" | "reverse";
 
   let {

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -13,7 +13,7 @@
   type LabelFormatter = (
     tick: number,
     index: number,
-    numberOfTicks: number,
+    ticksArrayLength: number,
   ) => string | number;
 
   type Polarity = "standard" | "reverse";

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -11,6 +11,12 @@
   }
   type Polarity = "standard" | "reverse";
 
+  type LabelFormatter = (
+    tick: number,
+    index: number,
+    numberOfTicks: number,
+  ) => string | number;
+
   // Props with defaults (Svelte 5 runes)
   let {
     ticksArray = $bindable<number[]>(),
@@ -23,13 +29,13 @@
     floor,
     ceiling,
     orientation,
-    labelFormatter,
     fontSize = 19,
     polarity = "standard",
     showGridlines = false,
     showTickMarks = false,
 
     strokeWidth = 2,
+    labelFormatter = undefined as LabelFormatter | undefined,
   }: {
     ticksArray?: number[]; // bindable
     chartWidth: number;
@@ -41,13 +47,13 @@
     floor?: number;
     ceiling?: number;
     orientation: Orientation;
-    labelFormatter?: (tick: number, index: number) => string;
     fontSize?: number;
     polarity?: Polarity;
     showGridlines?: Boolean;
     showTickMarks?: Boolean;
 
     strokeWidth?: number;
+    labelFormatter?: LabelFormatter;
   } = $props();
   function axisValue(fn: any, tick: number): number {
     // Try single-call first: axisFunction(tick)
@@ -201,7 +207,9 @@
             : "start"}
         fill="grey"
       >
-        {labelFormatter ? labelFormatter(tick, index) : defaultLabel(tick)}
+        {labelFormatter
+          ? labelFormatter(tick, index, ticksArray.length)
+          : defaultLabel(tick)}
       </text>
     </g>
   {/each}

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -14,7 +14,7 @@
   type LabelFormatter = (
     tick: number,
     index: number,
-    numberOfTicks: number,
+    ticksArrayLength: number,
   ) => string | number;
 
   // Props with defaults (Svelte 5 runes)

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -93,7 +93,7 @@
     skew = false,
     showTickMarks = true,
     showGridlines = false,
-    labelFormatter = (tick, index, numberOfTicks) => {
+    labelFormatter = (tick, index, ticksArrayLength) => {
       return tick;
     },
   } = $props();

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -93,6 +93,9 @@
     skew = false,
     showTickMarks = true,
     showGridlines = false,
+    labelFormatter = (tick, index, numberOfTicks) => {
+      return tick;
+    },
   } = $props();
 
   let xTicks = $state([]);
@@ -472,6 +475,7 @@
             {polarity}
             {showTickMarks}
             {showGridlines}
+            {labelFormatter}
           ></Axis>
         {/if}
         {#if showAverage}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -275,6 +275,17 @@
       ),
     );
   }
+
+  let totalHeight = $derived(
+    chartHeight +
+      (showAxis ? 25 : 0) +
+      (showAverage ? 35 : 0) +
+      (showArrows ? 25 : 0),
+  );
+
+  let svgHeight = $derived(
+    chartHeight + (showAxis ? 25 : 0) + (showAverage ? 35 : 0),
+  );
 </script>
 
 {#if annotations.length}
@@ -334,9 +345,10 @@
   class="grid-container"
   bind:this={container}
   style="
-  position: relative;
+    position: relative;
     grid-template-columns: {gridTemplateColumns};
-    grid-template-rows: {gridTemplateRows};
+    grid-template-columns: {gridTemplateRows};
+    height: {totalHeight}px;
   "
 >
   {#each allDataNormalized as positionChart, i}
@@ -360,18 +372,8 @@
         ></Button>
       </div>
     {/if}
-    <div
-      class="chart"
-      style="height:{chartHeight +
-        (showAxis ? 30 : 30) +
-        (showArrows ? 30 : 0) +
-        (showAverage ? 40 : 0)}px"
-      bind:clientWidth={chartWidth}
-    >
-      <svg
-        width={chartWidth}
-        height={chartHeight + (showAxis ? 40 : 0) + (showAverage ? 40 : 0)}
-      >
+    <div class="chart" bind:clientWidth={chartWidth}>
+      <svg width={chartWidth} height={svgHeight} overflow="visible">
         {#each range as number}
           <g
             transform="translate({markerRadius +
@@ -483,7 +485,7 @@
             transform="translate({xFunction(
               xTickFirst,
               xTickLast,
-            )(averageValue) + markerRadius}, {chartHeight * 1.7})"
+            )(averageValue) + markerRadius}, 45)"
           >
             <text
               fill="#444"

--- a/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
@@ -53,6 +53,7 @@
   .axis {
     display: flex;
     justify-content: space-between;
+    margin-bottom: 0;
   }
 
   .left-label,


### PR DESCRIPTION
- `labelFormatter` now has access to `ticksArray.length` so extreme labels can be formatted differently
- `labelFormatter` is passed down to Ticks from PositionChart via Axis
- Setting `overflow=visible` on the svg that contains the axis prevents long tick labels from getting cut off
- But various changes required to stop `overflow=visible` from disrupting the layout of the chart. In both the Histogram and PositionChart, this involves calculating the height once in the script, rather than adding together heights of various elements throughout the html.