### PR TITLE
Bugfix/histogram border

### DIFF
--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -207,14 +207,16 @@
           </g>
           {#each bins as bin, i}
             {#key bin.x0}
+              {@const fullWidth = Math.abs(xScale(bin.x1) - xScale(bin.x0))}
+              {@const barWidth = fullWidth * 0.97}
+              {@const offset = (fullWidth - barWidth) / 2}
               <rect
-                x={polarity === "reverse" ? xScale(bin.x1) : xScale(bin.x0)}
+                x={(polarity === "reverse" ? xScale(bin.x1) : xScale(bin.x0)) +
+                  offset}
                 y={height - yScale(bin.length)}
-                width={Math.abs(xScale(bin.x1) - xScale(bin.x0))}
+                width={barWidth}
                 height={yScale(bin.length)}
                 fill={fill ?? colorScale[i]}
-                stroke-width={barStrokeWidth}
-                stroke={barStrokeColor}
               ></rect>
             {/key}
           {/each}

--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -195,7 +195,7 @@
                 orientation={{ axis: "y", position: "left" }}
                 min={minY}
                 max={maxY}
-                domain={[0, yTickLast]}
+                domain={[yTickLast, 0]}
                 range={[0, height]}
                 fontSize={0}
                 numberOfTicks={4}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -347,7 +347,7 @@
   style="
     position: relative;
     grid-template-columns: {gridTemplateColumns};
-    grid-template-columns: {gridTemplateRows};
+    grid-template-rows: {gridTemplateRows};
     height: {totalHeight}px;
   "
 >


### PR DESCRIPTION
Bar width is now 97% of full width. This prevents need to provide a white stroke around the bars, which distorted their height (see https://github.com/communitiesuk/mhclg_svelte_component_library/pull/205)

A very small bar was difficult to distinguish from the bottom gridline, so this PR also flips the y-axis domain. This means gridlines start from the top of the chart, making bottom gridlines optional. This is a hacky fix as it means top gridlines are now no longer optional.