### PR TITLE
Bugfix/remove bottom gridline + invisible axis for positionChart

### DIFF
--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -208,12 +208,12 @@
               chartHeight={height}
               chartWidth={containerWidth - padding}
               orientation={{ axis: "y", position: "left" }}
-              min={minY}
-              max={maxY}
-              domain={[0, yTickLast]}
+              min={3}
+              max={9}
+              domain={[yTickLast, 0]}
               range={[0, height]}
               fontSize={0}
-              numberOfTicks={4}
+              numberOfTicks={3}
               {showGridlines}
               {showTickMarks}
               strokeWidth={tickStrokeWidth}

--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -208,8 +208,8 @@
               chartHeight={height}
               chartWidth={containerWidth - padding}
               orientation={{ axis: "y", position: "left" }}
-              min={3}
-              max={9}
+              min={minY}
+              max={maxY}
               domain={[yTickLast, 0]}
               range={[0, height]}
               fontSize={0}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -485,7 +485,8 @@
             transform="translate({xFunction(
               xTickFirst,
               xTickLast,
-            )(averageValue) + markerRadius}, 45)"
+            )(averageValue) + markerRadius}, {chartHeight +
+              (showAxis ? 20 : 0)})"
           >
             <text
               fill="#444"
@@ -553,6 +554,29 @@
       {markerRect}
       {tooltipSnippet}
     ></ValueLabel>
+  {/if}
+</div>
+
+<div style="content-visibility: hidden;">
+  {#if !showAxis}
+    <Axis
+      bind:ticksArray={xTicks}
+      {chartHeight}
+      chartWidth={chartWidth - markerRadius * 2}
+      orientation={{ axis: "x", position: "bottom" }}
+      range={[markerRadius, chartWidth - markerRadius]}
+      domain={[xTickFirst, xTickLast]}
+      {min}
+      {max}
+      fontSize={14}
+      {floor}
+      {ceiling}
+      {numberOfTicks}
+      {polarity}
+      {showTickMarks}
+      {showGridlines}
+      {labelFormatter}
+    ></Axis>
   {/if}
 </div>
 


### PR DESCRIPTION
Implements the hacky fix for removing bottom Histogram gridline described in https://github.com/communitiesuk/mhclg_svelte_component_library/pull/208

Also adds invisible axis to positionChart, to achieve the same purpose as in the Histogram in https://github.com/communitiesuk/mhclg_svelte_component_library/pull/202 - renders nice ticks even if axis not visible

