### PR TITLE
Align arrows with bar

### DIFF
--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -516,10 +516,7 @@
         {/if}
       </svg>
       {#if showArrows}
-        <div
-          class="axis-container"
-          style="margin-left: {markerRadius}px; margin-right: {markerRadius}px;"
-        >
+        <div class="axis-container" style="margin: 0px {markerRadius}px">
           <PositionChartAxis
             textSize="xs"
             axisLabels={["Worse than average", "Better than average"]}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -516,13 +516,15 @@
         {/if}
       </svg>
       {#if showArrows}
-        <PositionChartAxis
-          markerRadius={10}
-          barWidth={chartWidth}
-          textSize="xs"
-          {chartWidth}
-          axisLabels={["Worse than average", "Better than average"]}
-        ></PositionChartAxis>
+        <div
+          class="axis-container"
+          style="margin-left: {markerRadius}px; margin-right: {markerRadius}px;"
+        >
+          <PositionChartAxis
+            textSize="xs"
+            axisLabels={["Worse than average", "Better than average"]}
+          ></PositionChartAxis>
+        </div>
       {/if}
     </div>
     {#if moreInfoTogglesArray[i]}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -518,7 +518,7 @@
       {#if showArrows}
         <div class="axis-container" style="margin: 0px {markerRadius}px">
           <PositionChartAxis
-            textSize="xs"
+            textSize="s"
             axisLabels={["Worse than average", "Better than average"]}
           ></PositionChartAxis>
         </div>

--- a/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChartAxis.svelte
@@ -1,47 +1,47 @@
 <script>
-  let {
-    markerRadius = undefined,
-    textSize = "s",
-    chartWidth,
-    axisLabels = ["Left", "Right"],
-  } = $props();
+  let { textSize = "s", axisLabels = ["Left", "Right"] } = $props();
 </script>
 
-<div
-  class="axis govuk-body-{textSize}"
-  style="--axis-padding:{markerRadius}px; width: {chartWidth}"
->
-  <div class="right-label">
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="18"
-      height="16"
-      viewBox="0 0 11 20"
-      fill="none"
-    >
-      <path
-        transform="translate(20,21)rotate(180)"
-        d="M 19.7071 12.7071 C 20.0976 12.3166 20.0976 11.6834 19.7071 11.2929 L 13.3431 4.9289 C 12.9526 4.5384 12.3195 4.5384 11.9289 4.9289 C 11.5384 5.3195 11.5384 5.9526 11.9289 6.3431 L 17.5858 12 L 11.9289 17.6568 C 11.5384 18.0474 11.5384 18.6805 11.9289 19.0711 C 12.3195 19.4616 12.9526 19.4616 13.3431 19.0711 L 19.7071 12.7071 Z M 4 12 L 4 13 L 19 13 L 19 12 L 19 11 L 9 11 L 4 11 Z"
-        fill="darkgrey"
-      ></path>
-    </svg>
+<div class="axis govuk-body-{textSize}">
+  <div class="left-label">
+    <div class="arrow-container">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="16"
+        viewBox="0 0 18 16"
+      >
+        <path
+          d="M8 1L1 8L8 15M1 8H17"
+          stroke="darkgrey"
+          stroke-width="2"
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        ></path>
+      </svg>
+    </div>
     <span class="axis-text">{axisLabels[0]}</span>
   </div>
-  <div class="left-label">
+  <div class="right-label">
     <span class="axis-text">{axisLabels[1]}</span>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="18"
-      height="16"
-      viewBox="0 0 11 20"
-      fill="none"
-    >
-      <path
-        transform="translate(-5,-3)"
-        d="M 19.7071 12.7071 C 20.0976 12.3166 20.0976 11.6834 19.7071 11.2929 L 13.3431 4.9289 C 12.9526 4.5384 12.3195 4.5384 11.9289 4.9289 C 11.5384 5.3195 11.5384 5.9526 11.9289 6.3431 L 17.5858 12 L 11.9289 17.6568 C 11.5384 18.0474 11.5384 18.6805 11.9289 19.0711 C 12.3195 19.4616 12.9526 19.4616 13.3431 19.0711 L 19.7071 12.7071 Z M 4 12 L 4 13 L 19 13 L 19 12 L 19 11 L 9 11 L 4 11 Z"
-        fill="darkgrey"
-      ></path>
-    </svg>
+    <div class="arrow-container">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="16"
+        viewBox="0 0 18 16"
+      >
+        <path
+          d="M10 1L17 8L10 15M17 8H1"
+          stroke="darkgrey"
+          stroke-width="2"
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        ></path>
+      </svg>
+    </div>
   </div>
 </div>
 
@@ -59,10 +59,11 @@
   .left-label,
   .right-label {
     display: flex;
+    gap: 4px;
     max-width: 120px;
   }
 
-  .left-label {
+  .right-label {
     text-align: end;
   }
 
@@ -71,5 +72,10 @@
     line-height: 0.9;
     color: #666666;
     font-style: italic;
+  }
+
+  .arrow-container {
+    display: flex;
+    align-items: center;
   }
 </style>

--- a/src/wrappers/components/data-vis/position-chart/PositionChartWrapper.svelte
+++ b/src/wrappers/components/data-vis/position-chart/PositionChartWrapper.svelte
@@ -165,6 +165,13 @@
         description: "Whether to display an axis. Boolean.",
       },
       {
+        name: "showArrows",
+        category: "Display",
+        value: true,
+        description:
+          "Whether to display an arrows explaining chart direction. Boolean.",
+      },
+      {
         name: "value",
         category: "Data",
         value: 3,


### PR DESCRIPTION
I made the 'worse than average' and 'better than average' arrows align with the ends of the bar. This was done by wrapping the PositionChartAxis component in a div and adding left and right margins.

I also tidied up the PositionChartAxis component by simplifying the svg code and removing old code and props that weren't being used.

Finally, I added an option in the Position chart wrapper page to show the arrows.