### PR TITLE
add option for more compact summary text, plus expanded prop

### DIFF
--- a/src/lib/components/ui/Details.svelte
+++ b/src/lib/components/ui/Details.svelte
@@ -1,12 +1,18 @@
 <script>
-  let { summaryText, detailedText, renderStringAsHTML = false } = $props();
+  let {
+    summaryText,
+    detailedText,
+    renderStringAsHTML = false,
+    noInset = false,
+    expanded = $bindable(false),
+  } = $props();
 </script>
 
-<details class="govuk-details">
+<details class="govuk-details" bind:open={expanded}>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">{summaryText}</span>
   </summary>
-  <div class="govuk-details__text">
+  <div class={`govuk-details__text ${noInset === true ? "no-inset" : ""}`}>
     {#if typeof detailedText === "string"}
       {#if renderStringAsHTML}
         {@html detailedText}
@@ -18,3 +24,10 @@
     {/if}
   </div>
 </details>
+
+<style>
+  .no-inset {
+    padding: 0;
+    border: 0;
+  }
+</style>


### PR DESCRIPTION
- bindable `expanded` prop allows tracking of state outside the component, useful for closing a component when opening another
- `noInset` prop removes the inset text styling, for a more compact presentation