### PR TITLE
Added group and summary html render

### DIFF
--- a/src/lib/components/ui/Details.svelte
+++ b/src/lib/components/ui/Details.svelte
@@ -1,19 +1,29 @@
-<script>
+<script lang="ts">
   let {
     summaryText,
     detailedText,
     renderStringAsHTML = false,
     noInset = false,
     expanded = $bindable(false),
+    groupName
   } = $props();
 </script>
 
-<details class="govuk-details" bind:open={expanded}>
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">{summaryText}</span>
-  </summary>
-  <div class={`govuk-details__text ${noInset === true ? "no-inset" : ""}`}>
-    {#if typeof detailedText === "string"}
+<details
+        class="govuk-details"
+        open={expanded}
+        name={groupName}
+>
+  {#if renderStringAsHTML}
+    <summary class="govuk-details__summary-text">
+      {@html summaryText}
+    </summary>
+  {:else}
+    <summary class="govuk-details__summary-text">{summaryText}</summary>
+  {/if}
+
+  <div class={`govuk-details__text ${noInset === true ? 'no-inset' : ''}`}>
+    {#if typeof detailedText === 'string'}
       {#if renderStringAsHTML}
         {@html detailedText}
       {:else}


### PR DESCRIPTION
Added the ability to assign the details to a group. This allows for details be automatically closed when another one is opened. 

Also added the ability to render the summary title as HTML 