### PR TITLE
Feature/improve ticks

### DIFF
--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -238,6 +238,14 @@
                 height={yScale(bin.length)}
                 fill={fill ?? colorScale[i]}
               ></rect>
+              <text
+                x={(polarity === "reverse" ? xScale(bin.x1) : xScale(bin.x0)) +
+                  offset}
+                y={height - yScale(bin.length)}
+                font-size={5}
+                >{bin.length} areas between
+                {Math.round(bin.x0)} and {Math.round(bin.x1)}
+              </text>
             {/key}
           {/each}
         </g>

--- a/src/lib/components/data-vis/Histogram.svelte
+++ b/src/lib/components/data-vis/Histogram.svelte
@@ -42,42 +42,27 @@
     includeOutliers = true,
   } = $props();
 
-  let xTicks = $state([]);
-  let yTicks = $state([]);
-
-  let xTickFirst = $derived(xTicks.length ? xTicks[0] : 0);
-  let xTickLast = $derived(xTicks.length ? xTicks.at(-1) : 1);
-
-  let domainXMin = $derived(Math.min(xTickFirst, xTickLast));
-  let domainXMax = $derived(Math.max(xTickFirst, xTickLast));
-
-  let yTickFirst = $derived(yTicks.length ? yTicks[0] : 0);
-  let yTickLast = $derived(yTicks.length ? yTicks.at(-1) : 1);
-
-  let domainYMin = $derived(Math.min(yTickFirst, yTickLast));
-  let domainYMax = $derived(Math.max(yTickFirst, yTickLast));
-
   let useRange = $derived(
     polarity === "standard"
       ? [0, containerWidth - padding]
       : [containerWidth - padding, 0],
   );
 
-  let xScale = $derived(
-    scaleLinear().domain([domainXMin, domainXMax]).range(useRange),
-  );
+  let xValueFirst = $derived(polarity === "standard" ? minX : maxX);
+  let xValueLast = $derived(polarity === "standard" ? maxX : minX);
+
+  let xScale = $derived(scaleLinear().domain([minX, maxX]).range(useRange));
 
   const segmentScale = $derived(
-    scaleLinear().domain([0, nBins]).range([domainXMin, domainXMax]),
+    scaleLinear().domain([0, nBins]).range([minX, maxX]),
   );
 
   const binThresholds = $derived(d3range(1, nBins).map(segmentScale));
 
-  const binner = $derived(
-    bin().domain([domainXMin, domainXMax]).thresholds(binThresholds),
-  );
+  const binner = $derived(bin().domain([minX, maxX]).thresholds(binThresholds));
+
   const clampedDistribution = $derived(
-    distribution.map((d) => Math.min(Math.max(d, domainXMin), domainXMax)),
+    distribution.map((d) => Math.min(Math.max(d, minX), maxX)),
   );
 
   const binnedDistribution = $derived(
@@ -126,7 +111,7 @@
         .colors(2);
 
       const averageNormalised =
-        (averageValue - xTickFirst) / (xTickLast - xTickFirst);
+        (averageValue - xValueFirst) / (xValueLast - xValueFirst);
 
       const binColors = chroma
         .scale([extremeColors[0], midColor, extremeColors[1]])
@@ -150,8 +135,8 @@
       if (
         !midColor ||
         averageValue == null ||
-        xTickFirst == null ||
-        xTickLast == null
+        xValueFirst == null ||
+        xValueLast == null
       ) {
         return [];
       }
@@ -159,8 +144,6 @@
 
     return interpolateColors(startColor, endColor, nBins, midColor, skew);
   });
-
-  $inspect({ colorScale });
 
   const layout = $derived.by(() => {
     let y = 0;
@@ -194,6 +177,7 @@
         {#if topLabel && layout.topLabelY !== null}
           <text x={0} y={layout.topLabelY + 14} fill="#666" font-size="0.75em">
             Number of areas
+            {minX}, {maxX}
           </text>
         {/if}
 
@@ -217,21 +201,28 @@
 
         <g transform="translate(0, {layout.chartY})">
           {#if showYAxis}
-            <Axis
-              bind:ticksArray={yTicks}
-              chartHeight={height}
-              chartWidth={containerWidth - padding}
-              orientation={{ axis: "y", position: "left" }}
-              min={minY}
-              max={maxY}
-              domain={[yTickLast, 0]}
-              range={[0, height]}
-              fontSize={0}
-              numberOfTicks={3}
-              {showGridlines}
+            <!-- <Axis
+              bind:axisDomain
+              bind:ticksArray={ticksDomain}
+              {chartHeight}
+              chartWidth={chartWidth - markerRadius * 2}
+              orientation={{ axis: "x", position: "bottom" }}
+              range={[markerRadius, chartWidth - markerRadius]}
+              domain={[xValueFirst, xValueLast]}
+              {min}
+              {max}
+              fontSize={14}
+              {floor}
+              {ceiling}
+              {numberOfTicks}
+              {polarity}
               {showTickMarks}
-              strokeWidth={tickStrokeWidth}
-            />
+              {showGridlines}
+              {labelFormatter}
+              {niceTicks}
+              {markerRadius}
+              {distribution}
+            ></Axis> -->
           {/if}
 
           {#each bins as bin, i}
@@ -253,12 +244,12 @@
 
         {#if showXAxis && layout.xAxisY !== null}
           <g transform="translate(0, {layout.xAxisY})">
-            <Axis
+            <!-- <Axis
               bind:ticksArray={xTicks}
               chartHeight={height}
               chartWidth={containerWidth - padding}
               orientation={{ axis: "x", position: "bottom" }}
-              domain={[xTickFirst, xTickLast]}
+              domain={[xValueFirst, xValueLast]}
               min={minX}
               max={maxX}
               range={useRange}
@@ -267,7 +258,7 @@
               {ceiling}
               {labelFormatter}
               {numberOfTicks}
-            />
+            /> -->
           </g>
         {/if}
       </g>
@@ -277,20 +268,27 @@
 
 <div style="content-visibility: hidden;">
   {#if !showXAxis}
-    <Axis
-      bind:ticksArray={xTicks}
-      chartHeight={height}
-      chartWidth={containerWidth - padding}
+    <!-- <Axis
+      bind:axisDomain
+      bind:ticksArray={ticksDomain}
+      {chartHeight}
+      chartWidth={chartWidth - markerRadius * 2}
       orientation={{ axis: "x", position: "bottom" }}
-      domain={[xTickFirst, xTickLast]}
-      min={minX}
-      max={maxX}
-      range={useRange}
-      fontSize={13}
+      range={[markerRadius, chartWidth - markerRadius]}
+      domain={[xValueFirst, xValueLast]}
+      {min}
+      {max}
+      fontSize={14}
       {floor}
       {ceiling}
-      {labelFormatter}
       {numberOfTicks}
-    ></Axis>
+      {polarity}
+      {showTickMarks}
+      {showGridlines}
+      {labelFormatter}
+      {niceTicks}
+      {markerRadius}
+      {distribution}
+    ></Axis> -->
   {/if}
 </div>

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -25,6 +25,7 @@
     numberOfTicks = undefined as number | undefined,
 
     // Bindable, but avoid binding undefined – initialize as [] for safety
+    fullRange = $bindable<number[]>([]),
     ticksArray = $bindable<number[]>([]),
 
     // Values to derive ticks/domain from if ticksArray not provided
@@ -64,10 +65,10 @@
     chartHeight?: number;
     chartWidth?: number;
     numberOfTicks?: number;
+    fullRange?: number[];
     ticksArray?: number[];
     min?: number;
     max?: number;
-
     orientation?: Orientation;
     floor?: number;
     ceiling?: number;
@@ -138,14 +139,9 @@
     const max = Math.max(...arr);
 
     const ticksRange = Math.max(...ticksArray) - Math.min(...ticksArray);
-    console.log("ticksRange", ticksRange);
-    console.log("ticksArray", ticksArray);
 
     const lowerLimit = min - ticksRange * leftPad;
     const upperLimit = max + ticksRange * rightPad;
-
-    console.log("min", min);
-    console.log("max", max);
 
     const limitsOrdered = $derived(
       polarity === "standard"
@@ -155,9 +151,15 @@
     return limitsOrdered;
   }
 
-  let fullRange = $derived(
+  let computedFullRange = $derived(
     calculateRangeFromTicks(ticksArray, leftPad, rightPad),
   );
+
+  // Sync it upward whenever it changes
+  $effect(() => {
+    fullRange = computedFullRange;
+  });
+
   $inspect({ fullRange });
 </script>
 

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -155,7 +155,10 @@
     return limitsOrdered;
   }
 
-  let fullRange = calculateRangeFromTicks(ticksArray, leftPad, rightPad);
+  let fullRange = $derived(
+    calculateRangeFromTicks(ticksArray, leftPad, rightPad),
+  );
+  $inspect({ fullRange });
 </script>
 
 <g
@@ -175,7 +178,7 @@
   <g
     data-role="{orientation.axis}-axis"
     transform="translate({orientation.position !== 'right'
-      ? chartWidth * leftPad + markerRadius // / 2
+      ? chartWidth * leftPad + markerRadius
       : chartWidth},{orientation.position === 'bottom' ? 0 : 0})"
   >
     {#if ticksArray || (min && max)}

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -22,7 +22,7 @@
     chartHeight = 100,
     chartWidth = $bindable<number>(200),
     numberOfTicks = undefined as number | undefined,
-    axisRange = $bindable<number[]>([]),
+    axisDomain = $bindable<number[]>([]),
     ticksArray = $bindable<number[]>([]),
     min = undefined as number | undefined,
     max = undefined as number | undefined,
@@ -49,7 +49,7 @@
     chartHeight?: number;
     chartWidth?: number;
     numberOfTicks?: number;
-    axisRange?: number[];
+    axisDomain?: number[];
     ticksArray?: number[];
     min?: number;
     max?: number;
@@ -130,18 +130,20 @@
     leftPad,
     rightPad,
     polarity,
-  ): number[] {
+  ) {
     const ticksDomainRange = maxTick - minTick;
 
-    const lowerLimit = minTick - ticksDomainRange * leftPad;
-    const upperLimit = maxTick + ticksDomainRange * rightPad;
-
-    const limitsOrdered =
-      polarity === "standard"
-        ? [lowerLimit, upperLimit]
-        : [upperLimit, lowerLimit];
-
-    return limitsOrdered;
+    if (polarity === "standard") {
+      return [
+        minTick - ticksDomainRange * leftPad,
+        maxTick + ticksDomainRange * rightPad,
+      ];
+    } else {
+      return [
+        maxTick + ticksDomainRange * leftPad,
+        minTick - ticksDomainRange * rightPad,
+      ];
+    }
   }
 
   let fullAxisDomain = $derived(
@@ -149,7 +151,7 @@
   );
 
   $effect(() => {
-    axisRange = fullAxisDomain;
+    axisDomain = fullAxisDomain;
   });
 
   // const resolvedScale = $derived(() => {

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -57,8 +57,8 @@
     showTickMarks = false,
     strokeWidth = 2,
     niceTicks = true,
-    leftPad = 0,
-    rightPad = 0,
+    leftPad = 0 as number,
+    rightPad = 0 as number,
   }: {
     chartHeight?: number;
     chartWidth?: number;
@@ -132,6 +132,32 @@
     return base;
   });
   const axisFunction: AxisProjector = $derived((v: number) => resolvedScale(v));
+
+  function calculateRangeFromTicks(ticksArray, leftPad, rightPad): number[] {
+    const arr = Array.from(ticksArray);
+    const min = Math.min(...arr);
+    const max = Math.max(...arr);
+
+    const ticksRange = Math.max(...ticksArray) - Math.min(...ticksArray);
+    console.log("ticksRange", ticksRange);
+    console.log("ticksArray", ticksArray);
+
+    const lowerLimit = min - ticksRange * leftPad;
+    const upperLimit = max + ticksRange * rightPad;
+
+    console.log("min", min);
+    console.log("max", max);
+
+    const limitsOrdered = $derived(
+      polarity === "standard"
+        ? [lowerLimit, upperLimit]
+        : [upperLimit, lowerLimit],
+    );
+    return limitsOrdered;
+  }
+
+  let xxx = calculateRangeFromTicks(ticksArray, leftPad, rightPad);
+  $inspect({ xxx });
 </script>
 
 <g

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -58,9 +58,8 @@
     showTickMarks = false,
     strokeWidth = 2,
     niceTicks = true,
-    leftPad = 0 as number,
-    rightPad = 0 as number,
     markerRadius = 0 as number,
+    distribution = [],
   }: {
     chartHeight?: number;
     chartWidth?: number;
@@ -89,12 +88,40 @@
     showGridlines?: Boolean;
     showTickMarks?: Boolean;
     niceTicks?: Boolean;
-    leftPad?: Number;
-    rightPad?: Number;
     markerRadius?: Number;
+    distribution?: number[];
   } = $props();
 
-  // --- Helpers to compute default domain/range when not supplied ---
+  let minTick = $derived(Math.min(...ticksArray));
+  let maxTick = $derived(Math.max(...ticksArray));
+  let minValue = $derived(Math.min(...distribution));
+  let maxValue = $derived(Math.max(...distribution));
+
+  $inspect({ minTick, maxTick, minValue, maxValue, distribution });
+
+  let leftPad = $derived(
+    polarity === "standard"
+      ? minValue < minTick
+        ? 0.1
+        : 0
+      : polarity === "reverse"
+        ? maxValue > maxTick
+          ? 0.1
+          : 0
+        : 0,
+  );
+
+  let rightPad = $derived(
+    polarity === "standard"
+      ? maxValue > maxTick
+        ? 0.1
+        : 0
+      : polarity === "reverse"
+        ? minValue < minTick
+          ? 0.1
+          : 0
+        : 0,
+  );
   const innerWidth = $derived(
     Math.max(0, chartWidth - chartWidth * leftPad - chartWidth * rightPad),
   );
@@ -160,7 +187,7 @@
     fullRange = computedFullRange;
   });
 
-  $inspect({ fullRange });
+  $inspect({ leftPad, rightPad });
 </script>
 
 <g

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -81,15 +81,25 @@
   let maxValue = $derived(Math.max(...distribution));
 
   let leftPad = $derived(
-    polarity === "standard"
-      ? minValue < minTick
-        ? 0.1
-        : 0
-      : polarity === "reverse"
-        ? maxValue > maxTick
+    niceTicks
+      ? polarity === "standard"
+        ? minValue < minTick
           ? 0.1
           : 0
-        : 0,
+        : polarity === "reverse"
+          ? maxValue > maxTick
+            ? 0.1
+            : 0
+          : 0
+      : polarity === "standard"
+        ? minValue < min
+          ? 0.1
+          : 0
+        : polarity === "reverse"
+          ? maxValue > max
+            ? 0.1
+            : 0
+          : 0,
   );
 
   let rightPad = $derived(
@@ -195,26 +205,47 @@
   >
     {#if ticksArray || (min && max)}
       {#key numberOfTicks}
-        <Ticks
-          bind:ticksArray
-          tickWidth={widthForTicks}
-          chartHeight={heightForTicks}
-          {min}
-          {max}
-          {numberOfTicks}
-          {orientation}
-          {floor}
-          {ceiling}
-          {labelFormatter}
-          {fontSize}
-          {polarity}
-          {showGridlines}
-          {showTickMarks}
-          {strokeWidth}
-          {niceTicks}
-          {leftPad}
-          {rightPad}
-        />
+        {#if niceTicks}
+          <Ticks
+            bind:ticksArray
+            tickWidth={widthForTicks}
+            chartHeight={heightForTicks}
+            {min}
+            {max}
+            {numberOfTicks}
+            {orientation}
+            {floor}
+            {ceiling}
+            {labelFormatter}
+            {fontSize}
+            {polarity}
+            {showGridlines}
+            {showTickMarks}
+            {strokeWidth}
+            {niceTicks}
+          />
+        {:else}
+          <Ticks
+            bind:ticksArray
+            tickWidth={widthForTicks}
+            chartHeight={heightForTicks}
+            {min}
+            {max}
+            {numberOfTicks}
+            {orientation}
+            {floor}
+            {ceiling}
+            {labelFormatter}
+            {fontSize}
+            {polarity}
+            {showGridlines}
+            {showTickMarks}
+            {strokeWidth}
+            {niceTicks}
+            {leftPad}
+            {rightPad}
+          />
+        {/if}
       {/key}
     {/if}
   </g>

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -57,6 +57,8 @@
     showTickMarks = false,
     strokeWidth = 2,
     niceTicks = true,
+    leftPad = 0,
+    rightPad = 0,
   }: {
     chartHeight?: number;
     chartWidth?: number;
@@ -85,10 +87,14 @@
     showGridlines?: Boolean;
     showTickMarks?: Boolean;
     niceTicks?: Boolean;
+    leftPad?: Number;
+    rightPad?: Number;
   } = $props();
 
   // --- Helpers to compute default domain/range when not supplied ---
-  const innerWidth = $derived(Math.max(0, chartWidth));
+  const innerWidth = $derived(
+    Math.max(0, chartWidth - chartWidth * leftPad - chartWidth * rightPad),
+  );
   const innerHeight = $derived(Math.max(0, chartHeight));
 
   function computeDefaultDomain(): [number, number] {
@@ -108,16 +114,19 @@
       return [innerHeight, 0];
     }
   }
-  //Returns d3 scale function
+
+  const useDomain = $derived(domain ?? computeDefaultDomain());
+  const useRange = $derived([
+    0,
+    chartWidth - chartWidth * leftPad - chartWidth * rightPad,
+  ]); //Returns d3 scale function
   const resolvedScale = $derived(() => {
     const base: ScaleContinuousNumeric<number, number> = scale
       ? scale.copy()
       : scaleLinear<number, number>();
 
-    const useDomain = domain ?? computeDefaultDomain();
     base.domain(useDomain);
 
-    const useRange = range ?? computeDefaultRange(innerWidth, innerHeight);
     base.range(useRange);
 
     return base;
@@ -139,27 +148,34 @@
     stroke="grey"
     stroke-width="2px"
   ></line>
-  {#if ticksArray || (min && max)}
-    {#key numberOfTicks}
-      <Ticks
-        bind:ticksArray
-        {chartWidth}
-        {chartHeight}
-        {axisFunction}
-        {min}
-        {max}
-        {numberOfTicks}
-        {orientation}
-        {floor}
-        {ceiling}
-        {labelFormatter}
-        {fontSize}
-        {polarity}
-        {showGridlines}
-        {showTickMarks}
-        {strokeWidth}
-        {niceTicks}
-      />
-    {/key}
-  {/if}
+  <g
+    data-role="{orientation.axis}-axis"
+    transform="translate({orientation.position !== 'right'
+      ? chartWidth * leftPad + 15
+      : chartWidth},{orientation.position === 'bottom' ? 0 : 0})"
+  >
+    {#if ticksArray || (min && max)}
+      {#key numberOfTicks}
+        <Ticks
+          bind:ticksArray
+          {chartWidth}
+          {chartHeight}
+          {axisFunction}
+          {min}
+          {max}
+          {numberOfTicks}
+          {orientation}
+          {floor}
+          {ceiling}
+          {labelFormatter}
+          {fontSize}
+          {polarity}
+          {showGridlines}
+          {showTickMarks}
+          {strokeWidth}
+          {niceTicks}
+        />
+      {/key}
+    {/if}
+  </g>
 </g>

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -186,8 +186,6 @@
   $effect(() => {
     fullRange = computedFullRange;
   });
-
-  $inspect({ leftPad, rightPad });
 </script>
 
 <g

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -21,35 +21,20 @@
   let {
     chartHeight = 100,
     chartWidth = $bindable<number>(200),
-
     numberOfTicks = undefined as number | undefined,
-
-    // Bindable, but avoid binding undefined – initialize as [] for safety
-    fullRange = $bindable<number[]>([]),
+    axisRange = $bindable<number[]>([]),
     ticksArray = $bindable<number[]>([]),
-
-    // Values to derive ticks/domain from if ticksArray not provided
     min = undefined as number | undefined,
     max = undefined as number | undefined,
-
     orientation = { axis: "x", position: "bottom" } as Orientation,
-
     floor = undefined as number | undefined,
     ceiling = undefined as number | undefined,
-
     paddingTop = 100,
     paddingBottom = 100,
     paddingLeft = 0,
     paddingRight = 0,
-
     labelFormatter = undefined as LabelFormatter | undefined,
-
-    // --- New inputs for D3 scale + optional overrides ---
-    // A ready-made D3 continuous scale (linear/log/time, etc.)
-    // For this component we use numeric-only; time scales also implement numeric mapping.
     scale = undefined as ScaleContinuousNumeric<number, number> | undefined,
-
-    // Optional overrides for domain/range applied to a COPY of the provided scale
     domain = undefined as [number, number] | undefined,
     range = undefined as [number, number] | undefined,
     fontSize = 19,
@@ -64,7 +49,7 @@
     chartHeight?: number;
     chartWidth?: number;
     numberOfTicks?: number;
-    fullRange?: number[];
+    axisRange?: number[];
     ticksArray?: number[];
     min?: number;
     max?: number;
@@ -76,19 +61,17 @@
     paddingLeft?: number;
     paddingRight?: number;
     labelFormatter?: LabelFormatter;
-
-    // New
     scale?: ScaleContinuousNumeric<number, number>;
     domain?: [number, number];
     range?: [number, number];
     fontSize?: number;
     polarity?: Polarity;
     gridlines?: Boolean;
-    strokeWidth?: Number;
+    strokeWidth?: number;
     showGridlines?: Boolean;
     showTickMarks?: Boolean;
     niceTicks?: Boolean;
-    markerRadius?: Number;
+    markerRadius?: number;
     distribution?: number[];
   } = $props();
 
@@ -96,8 +79,6 @@
   let maxTick = $derived(Math.max(...ticksArray));
   let minValue = $derived(Math.min(...distribution));
   let maxValue = $derived(Math.max(...distribution));
-
-  $inspect({ minTick, maxTick, minValue, maxValue, distribution });
 
   let leftPad = $derived(
     polarity === "standard"
@@ -122,70 +103,68 @@
           : 0
         : 0,
   );
-  const innerWidth = $derived(
-    Math.max(0, chartWidth - chartWidth * leftPad - chartWidth * rightPad),
+
+  let widthForTicks = $derived(
+    chartWidth - chartWidth * leftPad - chartWidth * rightPad,
   );
-  const innerHeight = $derived(Math.max(0, chartHeight));
+  let heightForTicks = $derived(Math.max(0, chartHeight));
 
-  function computeDefaultDomain(): [number, number] {
-    const arr =
-      (ticksArray && ticksArray.length ? ticksArray : [min, max]) ?? [];
-    const dMin =
-      floor ?? (arr.length ? arr.reduce((a, b) => (a < b ? a : b)) : 0);
-    const dMax =
-      ceiling ?? (arr.length ? arr.reduce((a, b) => (a > b ? a : b)) : 1);
-    return [dMin, dMax];
-  }
+  // function computeDefaultDomain(): [number, number] {
+  //   const arr =
+  //     (ticksArray && ticksArray.length ? ticksArray : [min, max]) ?? [];
+  //   const dMin =
+  //     floor ?? (arr.length ? arr.reduce((a, b) => (a < b ? a : b)) : 0);
+  //   const dMax =
+  //     ceiling ?? (arr.length ? arr.reduce((a, b) => (a > b ? a : b)) : 1);
+  //   return [dMin, dMax];
+  // }
 
-  function computeDefaultRange(innerWidth, innerHeight): [number, number] {
-    if (orientation.axis === "x") {
-      return [0, innerWidth];
-    } else {
-      return [innerHeight, 0];
-    }
-  }
-  const useDomain = $derived(domain ?? computeDefaultDomain());
-  const useRange = $derived(computeDefaultRange(innerWidth, innerHeight)); //Returns d3 scale function
+  // const tickDomain = $derived([minTick, maxTick]);
+  // let tickRange = $derived(
+  //   orientation.axis === "x" ? [0, widthForTicks] : [heightForTicks, 0],
+  // );
 
-  const resolvedScale = $derived(() => {
-    const base: ScaleContinuousNumeric<number, number> = scale
-      ? scale.copy()
-      : scaleLinear<number, number>();
+  function calculateFullAxisDomain(
+    minTick,
+    maxTick,
+    leftPad,
+    rightPad,
+    polarity,
+  ): number[] {
+    const ticksDomainRange = maxTick - minTick;
 
-    base.domain(useDomain);
+    const lowerLimit = minTick - ticksDomainRange * leftPad;
+    const upperLimit = maxTick + ticksDomainRange * rightPad;
 
-    base.range(useRange);
-
-    return base;
-  });
-  const axisFunction: AxisProjector = $derived((v: number) => resolvedScale(v));
-
-  function calculateRangeFromTicks(ticksArray, leftPad, rightPad): number[] {
-    const arr = Array.from(ticksArray);
-    const min = Math.min(...arr);
-    const max = Math.max(...arr);
-
-    const ticksRange = Math.max(...ticksArray) - Math.min(...ticksArray);
-
-    const lowerLimit = min - ticksRange * leftPad;
-    const upperLimit = max + ticksRange * rightPad;
-
-    const limitsOrdered = $derived(
+    const limitsOrdered =
       polarity === "standard"
         ? [lowerLimit, upperLimit]
-        : [upperLimit, lowerLimit],
-    );
+        : [upperLimit, lowerLimit];
+
     return limitsOrdered;
   }
 
-  let computedFullRange = $derived(
-    calculateRangeFromTicks(ticksArray, leftPad, rightPad),
+  let fullAxisDomain = $derived(
+    calculateFullAxisDomain(minTick, maxTick, leftPad, rightPad, polarity),
   );
 
-  // Sync it upward whenever it changes
   $effect(() => {
-    fullRange = computedFullRange;
+    axisRange = fullAxisDomain;
   });
+
+  // const resolvedScale = $derived(() => {
+  //   const base: ScaleContinuousNumeric<number, number> = scale
+  //     ? scale.copy()
+  //     : scaleLinear<number, number>();
+
+  //   base.domain(fullAxisDomain);
+
+  //   base.range(chartWidth);
+
+  //   return base;
+  // });
+
+  // const axisFunction: AxisProjector = $derived((v: number) => resolvedScale(v));
 </script>
 
 <g
@@ -195,9 +174,13 @@
     : chartWidth},{orientation.position === 'bottom' ? chartHeight : 0})"
 >
   <line
-    x1={range[0]}
+    x1={markerRadius ?? 0}
     y1="0"
-    x2={orientation.axis === "x" ? range[1] : 0}
+    x2={orientation.axis === "x"
+      ? markerRadius
+        ? chartWidth + markerRadius
+        : chartWidth
+      : 0}
     y2={orientation.axis === "y" ? chartHeight : 0}
     stroke="grey"
     stroke-width="2px"
@@ -212,9 +195,8 @@
       {#key numberOfTicks}
         <Ticks
           bind:ticksArray
-          {chartWidth}
-          {chartHeight}
-          {axisFunction}
+          tickWidth={widthForTicks}
+          chartHeight={heightForTicks}
           {min}
           {max}
           {numberOfTicks}

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -20,7 +20,7 @@
 
   let {
     chartHeight = 100,
-    chartWidth = $bindable<number>(200),
+    chartWidth = 200,
     numberOfTicks = undefined as number | undefined,
     axisDomain = $bindable<number[]>([]),
     ticksArray = $bindable<number[]>([]),
@@ -66,19 +66,19 @@
     range?: [number, number];
     fontSize?: number;
     polarity?: Polarity;
-    gridlines?: Boolean;
+    gridlines?: boolean;
     strokeWidth?: number;
-    showGridlines?: Boolean;
-    showTickMarks?: Boolean;
-    niceTicks?: Boolean;
+    showGridlines?: boolean;
+    showTickMarks?: boolean;
+    niceTicks?: boolean;
     markerRadius?: number;
     distribution?: number[];
   } = $props();
 
-  let minTick = $derived(Math.min(...ticksArray));
-  let maxTick = $derived(Math.max(...ticksArray));
-  let minValue = $derived(Math.min(...distribution));
-  let maxValue = $derived(Math.max(...distribution));
+  let minTick = $derived(ticksArray.length ? Math.min(...ticksArray) : 0);
+  let maxTick = $derived(ticksArray.length ? Math.max(...ticksArray) : 1);
+  let minValue = $derived(distribution.length ? Math.min(...distribution) : 0);
+  let maxValue = $derived(distribution.length ? Math.max(...distribution) : 1);
 
   let leftPad = $derived(
     niceTicks
@@ -129,21 +129,6 @@
   );
   let heightForTicks = $derived(Math.max(0, chartHeight));
 
-  // function computeDefaultDomain(): [number, number] {
-  //   const arr =
-  //     (ticksArray && ticksArray.length ? ticksArray : [min, max]) ?? [];
-  //   const dMin =
-  //     floor ?? (arr.length ? arr.reduce((a, b) => (a < b ? a : b)) : 0);
-  //   const dMax =
-  //     ceiling ?? (arr.length ? arr.reduce((a, b) => (a > b ? a : b)) : 1);
-  //   return [dMin, dMax];
-  // }
-
-  // const tickDomain = $derived([minTick, maxTick]);
-  // let tickRange = $derived(
-  //   orientation.axis === "x" ? [0, widthForTicks] : [heightForTicks, 0],
-  // );
-
   function calculateFullAxisDomain(
     minTick,
     maxTick,
@@ -174,20 +159,6 @@
   $effect(() => {
     axisDomain = fullAxisDomain;
   });
-
-  // const resolvedScale = $derived(() => {
-  //   const base: ScaleContinuousNumeric<number, number> = scale
-  //     ? scale.copy()
-  //     : scaleLinear<number, number>();
-
-  //   base.domain(fullAxisDomain);
-
-  //   base.range(chartWidth);
-
-  //   return base;
-  // });
-
-  // const axisFunction: AxisProjector = $derived((v: number) => resolvedScale(v));
 </script>
 
 <g

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -59,6 +59,7 @@
     niceTicks = true,
     leftPad = 0 as number,
     rightPad = 0 as number,
+    markerRadius = 0 as number,
   }: {
     chartHeight?: number;
     chartWidth?: number;
@@ -89,6 +90,7 @@
     niceTicks?: Boolean;
     leftPad?: Number;
     rightPad?: Number;
+    markerRadius?: Number;
   } = $props();
 
   // --- Helpers to compute default domain/range when not supplied ---
@@ -114,12 +116,9 @@
       return [innerHeight, 0];
     }
   }
-
   const useDomain = $derived(domain ?? computeDefaultDomain());
-  const useRange = $derived([
-    0,
-    chartWidth - chartWidth * leftPad - chartWidth * rightPad,
-  ]); //Returns d3 scale function
+  const useRange = $derived(computeDefaultRange(innerWidth, innerHeight)); //Returns d3 scale function
+
   const resolvedScale = $derived(() => {
     const base: ScaleContinuousNumeric<number, number> = scale
       ? scale.copy()
@@ -156,8 +155,7 @@
     return limitsOrdered;
   }
 
-  let xxx = calculateRangeFromTicks(ticksArray, leftPad, rightPad);
-  $inspect({ xxx });
+  let fullRange = calculateRangeFromTicks(ticksArray, leftPad, rightPad);
 </script>
 
 <g
@@ -177,7 +175,7 @@
   <g
     data-role="{orientation.axis}-axis"
     transform="translate({orientation.position !== 'right'
-      ? chartWidth * leftPad + 15
+      ? chartWidth * leftPad + markerRadius // / 2
       : chartWidth},{orientation.position === 'bottom' ? 0 : 0})"
   >
     {#if ticksArray || (min && max)}
@@ -200,6 +198,8 @@
           {showTickMarks}
           {strokeWidth}
           {niceTicks}
+          {leftPad}
+          {rightPad}
         />
       {/key}
     {/if}

--- a/src/lib/components/data-vis/axis/Axis.svelte
+++ b/src/lib/components/data-vis/axis/Axis.svelte
@@ -103,15 +103,25 @@
   );
 
   let rightPad = $derived(
-    polarity === "standard"
-      ? maxValue > maxTick
-        ? 0.1
-        : 0
-      : polarity === "reverse"
-        ? minValue < minTick
+    niceTicks
+      ? polarity === "standard"
+        ? maxValue > maxTick
           ? 0.1
           : 0
-        : 0,
+        : polarity === "reverse"
+          ? minValue < minTick
+            ? 0.1
+            : 0
+          : 0
+      : polarity === "standard"
+        ? maxValue > max
+          ? 0.1
+          : 0
+        : polarity === "reverse"
+          ? minValue < min
+            ? 0.1
+            : 0
+          : 0,
   );
 
   let widthForTicks = $derived(
@@ -142,16 +152,17 @@
     polarity,
   ) {
     const ticksDomainRange = maxTick - minTick;
+    const axisDomainRange = ticksDomainRange / (1 - leftPad - rightPad);
 
     if (polarity === "standard") {
       return [
-        minTick - ticksDomainRange * leftPad,
-        maxTick + ticksDomainRange * rightPad,
+        minTick - axisDomainRange * leftPad,
+        maxTick + axisDomainRange * rightPad,
       ];
     } else {
       return [
-        maxTick + ticksDomainRange * leftPad,
-        minTick - ticksDomainRange * rightPad,
+        maxTick + axisDomainRange * leftPad,
+        minTick - axisDomainRange * rightPad,
       ];
     }
   }

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -100,10 +100,14 @@
     ticksArray = ticksOrdered;
   });
 
+  let ticksDomain = $derived(
+    polarity === "standard"
+      ? [Math.min(...ticksArray), Math.max(...ticksArray)]
+      : [Math.max(...ticksArray), Math.min(...ticksArray)],
+  );
+
   let axisFunction = $derived(
-    scaleLinear()
-      .domain([Math.min(...ticksArray), Math.max(...ticksArray)])
-      .range([0, tickWidth]),
+    scaleLinear().domain(ticksDomain).range([0, tickWidth]),
   );
 </script>
 

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Decimal from "decimal.js";
-  import { ticks, tickStep, range } from "d3-array";
+  import { ticks, tickStep, range, nice } from "d3-array";
 
   // Types
   type Axis = "x" | "y";
@@ -38,8 +38,6 @@
     strokeWidth = 2,
     labelFormatter = undefined as LabelFormatter | undefined,
     niceTicks = true,
-    leftPad = 0 as number,
-    rightPad = 0 as number,
   }: {
     ticksArray?: number[]; // bindable
     chartWidth: number;
@@ -167,34 +165,13 @@
     return out;
   }
 
-  function asymmetricTicks(min, max, computedTickCount, niceStart, niceStop) {
-    const step = tickStep(min, max, computedTickCount);
-    console.log(step);
-
-    const lo =
-      niceStart > 0
-        ? Math.floor(min / step) * step // snap outward (nice)
-        : Math.ceil(min / step) * step; // snap inward (inclusive)
-    console.log(niceStart > 0);
-    console.log(niceStop > 0);
-
-    const hi =
-      niceStop > 0
-        ? Math.ceil(max / step) * step // snap outward (nice)
-        : Math.floor(max / step) * step; // snap inward (inclusive)
-
-    return range(lo, hi + step / 2, step); // +step/2 avoids float exclusion of hi
-  }
-
   // Compute ticks
   let computedTickCount = $derived(
     numberOfTicks ?? tickCount(chartWidth, chartHeight),
   );
 
   let rawTicks = $derived(
-    niceTicks
-      ? asymmetricTicks(min, max, computedTickCount, leftPad, rightPad)
-      : [min, max],
+    niceTicks ? nice(min, max, computedTickCount) : [min, max],
   );
 
   let ticksOrdered = $derived(

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -70,6 +70,10 @@
     const inner = fn();
     return inner(tick);
   }
+  const NICE_STEPS = [1, 2, 2.5, 5, 10];
+  const TICK_PENALTY_WEIGHT = 1;
+  const PADDING_PENALTY_WEIGHT = 10;
+  const MAX_TICK_MULTIPLIER = 3;
 
   function generateTicks(
     min: number,
@@ -78,36 +82,56 @@
     floorVal?: number,
     ceilingVal?: number,
   ): number[] {
-    let minVal =
-      floorVal !== undefined ? new Decimal(floorVal) : new Decimal(min);
+    const lo = floorVal ?? min;
+    const hi = ceilingVal ?? max;
 
-    let maxVal =
-      ceilingVal !== undefined ? new Decimal(ceilingVal) : new Decimal(max);
+    if (numTicks < 2) return [lo];
+    if (hi <= lo) return [lo, hi];
 
-    const rangeVal = maxVal.minus(minVal);
-    const roughStep = rangeVal.div(numTicks - 1);
-    const normalizedSteps = [
-      1, 2, 2.5, 3, 4, 5, 6, 8, 10, 12, 15, 25, 30, 35, 40, 45,
-    ];
-    const stepPower = Decimal.pow(
-      10,
-      -Math.floor(Math.log10(roughStep.toNumber())),
-    );
+    const roughStep = (hi - lo) / (numTicks - 1);
+    const magnitude = Math.pow(10, Math.floor(Math.log10(roughStep)));
 
-    const normalizedStep = roughStep.mul(stepPower);
-    const chosen = normalizedSteps.find(
-      (step) => step >= normalizedStep.toNumber(),
-    );
-    const optimalStep = new Decimal(chosen ?? 10).div(stepPower);
+    // Candidate steps: nice multiples at this magnitude and its neighbors
+    const candidates = [-1, 0, 1]
+      .flatMap((offset) =>
+        NICE_STEPS.map((s) => s * magnitude * Math.pow(10, offset)),
+      )
+      .filter((s, i, arr) => arr.indexOf(s) === i) // deduplicate
+      .sort((a, b) => a - b);
 
-    const scaleMin = minVal.div(optimalStep).floor().mul(optimalStep);
-    const scaleMax = maxVal.div(optimalStep).ceil().mul(optimalStep);
-
-    const ticks: number[] = [];
-    for (let i = scaleMin; i.lte(scaleMax); i = i.plus(optimalStep)) {
-      ticks.push(i.toNumber());
+    function tickBounds(step: number): {
+      start: number;
+      end: number;
+      count: number;
+    } {
+      const start = lo % step === 0 ? lo : Math.floor(lo / step) * step;
+      const end = Math.ceil(hi / step) * step;
+      const count = Math.round((end - start) / step) + 1;
+      return { start, end, count };
     }
-    return ticks;
+
+    function score(step: number): number {
+      const { start, end, count } = tickBounds(step);
+      const paddingPenalty = (end - start) / (hi - lo) - 1;
+      const countPenalty = Math.abs(count - numTicks);
+      return (
+        paddingPenalty * PADDING_PENALTY_WEIGHT +
+        countPenalty * TICK_PENALTY_WEIGHT
+      );
+    }
+
+    const bestStep = candidates
+      .filter(
+        (step) => tickBounds(step).count <= numTicks * MAX_TICK_MULTIPLIER,
+      )
+      .reduce((best, step) => (score(step) < score(best) ? step : best));
+
+    // Use Decimal only here, to avoid float drift in the loop
+    const { start, count } = tickBounds(bestStep);
+    const step = new Decimal(bestStep);
+    return Array.from({ length: count }, (_, i) =>
+      new Decimal(start).plus(step.mul(i)).toNumber(),
+    );
   }
 
   // Default label when no labelFormatter is supplied

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Decimal from "decimal.js";
+  import { ticks } from "d3-array";
 
   // Types
   type Axis = "x" | "y";

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Decimal from "decimal.js";
-  import { ticks } from "d3-array";
+  import { ticks, tickStep, range } from "d3-array";
 
   // Types
   type Axis = "x" | "y";
@@ -38,6 +38,8 @@
     strokeWidth = 2,
     labelFormatter = undefined as LabelFormatter | undefined,
     niceTicks = true,
+    leftPad = 0 as number,
+    rightPad = 0 as number,
   }: {
     ticksArray?: number[]; // bindable
     chartWidth: number;
@@ -57,6 +59,8 @@
     strokeWidth?: number;
     labelFormatter?: LabelFormatter;
     niceTicks?: Boolean;
+    leftPad?: Number;
+    rightPad?: Number;
   } = $props();
   function axisValue(fn: any, tick: number): number {
     // Try single-call first: axisFunction(tick)
@@ -163,9 +167,31 @@
     return out;
   }
 
+  function asymmetricTicks(min, max, computedTickCount, niceStart, niceStop) {
+    const step = tickStep(min, max, computedTickCount);
+    console.log(step);
+
+    const lo =
+      niceStart > 0
+        ? Math.floor(min / step) * step // snap outward (nice)
+        : Math.ceil(min / step) * step; // snap inward (inclusive)
+    console.log(niceStart > 0);
+    console.log(niceStop > 0);
+
+    const hi =
+      niceStop > 0
+        ? Math.ceil(max / step) * step // snap outward (nice)
+        : Math.floor(max / step) * step; // snap inward (inclusive)
+
+    return range(lo, hi + step / 2, step); // +step/2 avoids float exclusion of hi
+  }
+
   // Compute ticks
   let computedTickCount = $derived(
     numberOfTicks ?? tickCount(chartWidth, chartHeight),
+  );
+  let testTicks = $derived(
+    asymmetricTicks(min, max, computedTickCount, leftPad, rightPad),
   );
 
   let rawTicks = $derived(

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -196,7 +196,7 @@
 
   let rawTicks = $derived(
     niceTicks
-      ? generateTicks(min, max, computedTickCount, floor, ceiling)
+      ? asymmetricTicks(min, max, computedTickCount, leftPad, rightPad)
       : [min, max],
   );
 

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -171,7 +171,9 @@
   );
 
   let rawTicks = $derived(
-    niceTicks ? nice(min, max, computedTickCount) : [min, max],
+    niceTicks
+      ? ticks(...nice(min, max, computedTickCount), computedTickCount)
+      : [min, max],
   );
 
   let ticksOrdered = $derived(

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -28,8 +28,6 @@
     min,
     max,
     numberOfTicks,
-    floor,
-    ceiling,
     orientation,
     fontSize = 19,
     polarity = "standard",
@@ -47,16 +45,14 @@
     min: number;
     max: number;
     numberOfTicks?: number;
-    floor?: number;
-    ceiling?: number;
     orientation: Orientation;
     fontSize?: number;
     polarity?: Polarity;
-    showGridlines?: Boolean;
-    showTickMarks?: Boolean;
+    showGridlines?: boolean;
+    showTickMarks?: boolean;
     strokeWidth?: number;
     labelFormatter?: LabelFormatter;
-    niceTicks?: Boolean;
+    niceTicks?: boolean;
     leftPad?: number;
     rightPad?: number;
   } = $props();
@@ -99,7 +95,7 @@
   );
 
   let ticksOrdered = $derived(
-    polarity === "standard" ? rawTicks : rawTicks.reverse(),
+    polarity === "standard" ? rawTicks : [...rawTicks].toReversed(),
   );
 
   $effect(() => {

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import Decimal from "decimal.js";
   import { ticks, tickStep, range, nice } from "d3-array";
+  import { scaleLinear } from "d3-scale";
+  import Axis from "./Axis.svelte";
 
   // Types
   type Axis = "x" | "y";
@@ -21,9 +23,8 @@
   // Props with defaults (Svelte 5 runes)
   let {
     ticksArray = $bindable<number[]>(),
-    chartWidth,
+    tickWidth,
     chartHeight,
-    axisFunction,
     min,
     max,
     numberOfTicks,
@@ -34,15 +35,13 @@
     polarity = "standard",
     showGridlines = false,
     showTickMarks = false,
-
     strokeWidth = 2,
     labelFormatter = undefined as LabelFormatter | undefined,
     niceTicks = true,
   }: {
     ticksArray?: number[]; // bindable
-    chartWidth: number;
+    tickWidth: number;
     chartHeight: number;
-    axisFunction: any;
     min: number;
     max: number;
     numberOfTicks?: number;
@@ -53,89 +52,25 @@
     polarity?: Polarity;
     showGridlines?: Boolean;
     showTickMarks?: Boolean;
-
     strokeWidth?: number;
     labelFormatter?: LabelFormatter;
     niceTicks?: Boolean;
     leftPad?: Number;
     rightPad?: Number;
   } = $props();
-  function axisValue(fn: any, tick: number): number {
-    // Try single-call first: axisFunction(tick)
-    try {
-      const v = fn(tick);
-      if (typeof v === "number") return v;
-    } catch {
-      // ignore
-    }
+  // function axisValue(fn: any, tick: number): number {
+  //   // Try single-call first: axisFunction(tick)
+  //   try {
+  //     const v = fn(tick);
+  //     if (typeof v === "number") return v;
+  //   } catch {
+  //     // ignore
+  //   }
 
-    // Fallback: axisFunction()(tick)
-    const inner = fn();
-    return inner(tick);
-  }
-  const NICE_STEPS = [1, 2, 2.5, 5, 10];
-  const TICK_PENALTY_WEIGHT = 1;
-  const PADDING_PENALTY_WEIGHT = 10;
-  const MAX_TICK_MULTIPLIER = 3;
-
-  function generateTicks(
-    min: number,
-    max: number,
-    numTicks: number,
-    floorVal?: number,
-    ceilingVal?: number,
-  ): number[] {
-    const lo = floorVal ?? min;
-    const hi = ceilingVal ?? max;
-
-    if (numTicks < 2) return [lo];
-    if (hi <= lo) return [lo, hi];
-
-    const roughStep = (hi - lo) / (numTicks - 1);
-    const magnitude = Math.pow(10, Math.floor(Math.log10(roughStep)));
-
-    // Candidate steps: nice multiples at this magnitude and its neighbors
-    const candidates = [-1, 0, 1]
-      .flatMap((offset) =>
-        NICE_STEPS.map((s) => s * magnitude * Math.pow(10, offset)),
-      )
-      .filter((s, i, arr) => arr.indexOf(s) === i) // deduplicate
-      .sort((a, b) => a - b);
-
-    function tickBounds(step: number): {
-      start: number;
-      end: number;
-      count: number;
-    } {
-      const start = lo % step === 0 ? lo : Math.floor(lo / step) * step;
-      const end = Math.ceil(hi / step) * step;
-      const count = Math.round((end - start) / step) + 1;
-      return { start, end, count };
-    }
-
-    function score(step: number): number {
-      const { start, end, count } = tickBounds(step);
-      const paddingPenalty = (end - start) / (hi - lo) - 1;
-      const countPenalty = Math.abs(count - numTicks);
-      return (
-        paddingPenalty * PADDING_PENALTY_WEIGHT +
-        countPenalty * TICK_PENALTY_WEIGHT
-      );
-    }
-
-    const bestStep = candidates
-      .filter(
-        (step) => tickBounds(step).count <= numTicks * MAX_TICK_MULTIPLIER,
-      )
-      .reduce((best, step) => (score(step) < score(best) ? step : best));
-
-    // Use Decimal only here, to avoid float drift in the loop
-    const { start, count } = tickBounds(bestStep);
-    const step = new Decimal(bestStep);
-    return Array.from({ length: count }, (_, i) =>
-      new Decimal(start).plus(step.mul(i)).toNumber(),
-    );
-  }
+  //   // Fallback: axisFunction()(tick)
+  //   const inner = fn();
+  //   return inner(tick);
+  // }
 
   // Default label when no labelFormatter is supplied
   function defaultLabel(tick: number): string {
@@ -143,31 +78,12 @@
   }
 
   function tickCount(w: number, h: number): number {
-    // Keep behavior aligned with your original code.
     const tickNum = orientation.axis === "y" ? h / 50 : w / 50;
     return tickNum;
   }
-  function clampTickEnds(
-    ticks: number[],
-    floor?: number,
-    ceiling?: number,
-  ): number[] {
-    if (!ticks || ticks.length === 0) return ticks;
 
-    const out = ticks.slice();
-
-    if (floor !== undefined && out[0] <= floor) {
-      out[0] = floor;
-    }
-    if (ceiling !== undefined && out[out.length - 1] >= ceiling) {
-      out[out.length - 1] = ceiling;
-    }
-    return out;
-  }
-
-  // Compute ticks
   let computedTickCount = $derived(
-    numberOfTicks ?? tickCount(chartWidth, chartHeight),
+    numberOfTicks ?? tickCount(tickWidth, chartHeight),
   );
 
   let rawTicks = $derived(
@@ -180,15 +96,23 @@
     polarity === "standard" ? rawTicks : rawTicks.reverse(),
   );
 
-  ticksArray = ticksOrdered;
+  $effect(() => {
+    ticksArray = ticksOrdered;
+  });
+
+  let axisFunction = $derived(
+    scaleLinear()
+      .domain([Math.min(...ticksArray), Math.max(...ticksArray)])
+      .range([0, tickWidth]),
+  );
 </script>
 
 {#if axisFunction && ticksArray && orientation.axis && orientation.position}
   {#each ticksArray as tick, index}
     <g
       transform="translate(
-        {orientation.axis === 'x' ? axisValue(axisFunction, tick) : 0},
-        {orientation.axis === 'y' ? axisValue(axisFunction, tick) : 0}
+        {orientation.axis === 'x' ? axisFunction(tick) : 0},
+        {orientation.axis === 'y' ? axisFunction(tick) : 0}
       )"
     >
       {#if showTickMarks}
@@ -208,8 +132,8 @@
         <path
           d={orientation.axis === "y"
             ? orientation.position === "left"
-              ? `M0 0 l${chartWidth} 0`
-              : `M0 0 l-${chartWidth} 0`
+              ? `M0 0 l${tickWidth} 0`
+              : `M0 0 l-${tickWidth} 0`
             : orientation.position === "top"
               ? `M0 0 l0 ${chartHeight}`
               : `M0 0 l0 -${chartHeight}`}

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -38,6 +38,8 @@
     strokeWidth = 2,
     labelFormatter = undefined as LabelFormatter | undefined,
     niceTicks = true,
+    leftPad = 0,
+    rightPad = 0,
   }: {
     ticksArray?: number[]; // bindable
     tickWidth: number;
@@ -55,8 +57,8 @@
     strokeWidth?: number;
     labelFormatter?: LabelFormatter;
     niceTicks?: Boolean;
-    leftPad?: Number;
-    rightPad?: Number;
+    leftPad?: number;
+    rightPad?: number;
   } = $props();
   // function axisValue(fn: any, tick: number): number {
   //   // Try single-call first: axisFunction(tick)
@@ -89,7 +91,11 @@
   let rawTicks = $derived(
     niceTicks
       ? ticks(...nice(min, max, computedTickCount), computedTickCount)
-      : [min, max],
+      : leftPad || rightPad
+        ? polarity === "standard"
+          ? [min + (max - min) * leftPad, max - (max - min) * rightPad]
+          : [min + (max - min) * rightPad, max - (max - min) * leftPad]
+        : [min, max],
   );
 
   let ticksOrdered = $derived(

--- a/src/lib/components/data-vis/axis/Ticks.svelte
+++ b/src/lib/components/data-vis/axis/Ticks.svelte
@@ -190,9 +190,6 @@
   let computedTickCount = $derived(
     numberOfTicks ?? tickCount(chartWidth, chartHeight),
   );
-  let testTicks = $derived(
-    asymmetricTicks(min, max, computedTickCount, leftPad, rightPad),
-  );
 
   let rawTicks = $derived(
     niceTicks

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -100,9 +100,8 @@
     leftPad = 0,
     rightPad = 0,
     xTicks = $bindable([[]]),
+    xRange = $bindable([[]]),
   } = $props();
-
-  $inspect({ leftPad, rightPad });
 
   let xTickFirst = $derived(xTicks.length ? xTicks[0] : 0);
   let xTickLast = $derived(xTicks.length ? xTicks.at(-1) : 1);
@@ -466,6 +465,7 @@
         {/each}
         {#if showAxis}
           <Axis
+            bind:fullRange={xRange}
             bind:ticksArray={xTicks}
             {chartHeight}
             chartWidth={chartWidth - markerRadius * 2}
@@ -564,10 +564,14 @@
     ></ValueLabel>
   {/if}
 </div>
+<p>L: {leftPad}, R: {rightPad}</p>
+<p>xTicks: {xTicks}</p>
+<p>xRange: {xRange}</p>
 
 <div style="content-visibility: hidden;">
   {#if !showAxis}
     <Axis
+      bind:fullRange={xRange}
       bind:ticksArray={xTicks}
       {chartHeight}
       chartWidth={chartWidth - markerRadius * 2}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -97,15 +97,18 @@
       return tick;
     },
     niceTicks = true,
-    xTicks = $bindable([[]]),
-    xRange = $bindable([[]]),
+    ticksDomain = $bindable([[]]),
+    axisDomain = $bindable([[]]),
   } = $props();
 
-  let xTickFirst = $derived(xTicks.length ? xTicks[0] : 0);
-  let xTickLast = $derived(xTicks.length ? xTicks.at(-1) : 1);
+  let xTickFirst = $derived(ticksDomain.length ? ticksDomain[0] : 0);
+  let xTickLast = $derived(ticksDomain.length ? ticksDomain.at(-1) : 1);
 
-  let domainMin = $derived(Math.min(xTickFirst, xTickLast));
-  let domainMax = $derived(Math.max(xTickFirst, xTickLast));
+  let domainMin = $derived(Math.min(...axisDomain));
+  let domainMax = $derived(Math.max(...axisDomain));
+  let chartDomain = $derived(
+    polarity === "standard" ? [domainMin, domainMax] : [domainMax, domainMin],
+  );
 
   const segmentScale = $derived(
     scaleLinear().domain([0, nSegments]).range([domainMin, domainMax]),
@@ -241,8 +244,8 @@
   let barWidth = $derived(chartWidth - markerRadius * 2);
   let barHeight = $derived((chartHeight * 5) / 6);
 
-  function xFunction(min, max) {
-    return scaleLinear().domain([min, max]).range([0, barWidth]).clamp(true);
+  function xFunction(chartDomain) {
+    return scaleLinear().domain(chartDomain).range([0, barWidth]).clamp(true);
   }
 
   let annotations = $derived(
@@ -325,7 +328,7 @@
           </marker>
         </defs>
         <path
-          d="M 4 25 v 10 h {xFunction(min, max)(d.value) +
+          d="M 4 25 v 10 h {xFunction(chartDomain)(d.value) +
             markerRadius -
             4 +
             (topWidth - chartWidth)}  v 15"
@@ -414,11 +417,8 @@
                   ? (e) => e.key === "Enter" && onClickMarker(e, value)
                   : null}
                 pointer-events={interactiveMarkers ? null : "none"}
-                transform="translate({xFunction(
-                  xRange[0],
-                  xRange[1],
-                )(rowValue.value) + markerRadius},{positionChart.chartHeight /
-                  2})"
+                transform="translate({xFunction(chartDomain)(rowValue.value) +
+                  markerRadius},{positionChart.chartHeight / 2})"
               >
                 {#if rowValue.shape === "line"}
                   <line
@@ -463,8 +463,8 @@
         {/each}
         {#if showAxis}
           <Axis
-            bind:fullAxisRange={xRange}
-            bind:ticksArray={xTicks}
+            bind:axisDomain
+            bind:ticksArray={ticksDomain}
             {chartHeight}
             chartWidth={chartWidth - markerRadius * 2}
             orientation={{ axis: "x", position: "bottom" }}
@@ -487,11 +487,8 @@
         {/if}
         {#if showAverage}
           <g
-            transform="translate({xFunction(
-              xRange[0],
-              xRange[1],
-            )(averageValue) + markerRadius}, {chartHeight +
-              (showAxis ? 20 : 0)})"
+            transform="translate({xFunction(chartDomain)(averageValue) +
+              markerRadius}, {chartHeight + (showAxis ? 20 : 0)})"
           >
             <text
               fill="#444"
@@ -565,8 +562,8 @@
 <div style="content-visibility: hidden;">
   {#if !showAxis}
     <Axis
-      bind:fullAxisRange={xRange}
-      bind:ticksArray={xTicks}
+      bind:axisDomain
+      bind:ticksArray={ticksDomain}
       {chartHeight}
       chartWidth={chartWidth - markerRadius * 2}
       orientation={{ axis: "x", position: "bottom" }}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -415,8 +415,8 @@
                   : null}
                 pointer-events={interactiveMarkers ? null : "none"}
                 transform="translate({xFunction(
-                  xTickFirst,
-                  xTickLast,
+                  xRange[0],
+                  xRange[1],
                 )(rowValue.value) + markerRadius},{positionChart.chartHeight /
                   2})"
               >
@@ -463,7 +463,7 @@
         {/each}
         {#if showAxis}
           <Axis
-            bind:fullRange={xRange}
+            bind:fullAxisRange={xRange}
             bind:ticksArray={xTicks}
             {chartHeight}
             chartWidth={chartWidth - markerRadius * 2}
@@ -488,8 +488,8 @@
         {#if showAverage}
           <g
             transform="translate({xFunction(
-              xTickFirst,
-              xTickLast,
+              xRange[0],
+              xRange[1],
             )(averageValue) + markerRadius}, {chartHeight +
               (showAxis ? 20 : 0)})"
           >
@@ -565,7 +565,7 @@
 <div style="content-visibility: hidden;">
   {#if !showAxis}
     <Axis
-      bind:fullRange={xRange}
+      bind:fullAxisRange={xRange}
       bind:ticksArray={xTicks}
       {chartHeight}
       chartWidth={chartWidth - markerRadius * 2}

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -97,6 +97,8 @@
       return tick;
     },
     niceTicks = true,
+    leftPad = 0.1,
+    rightPad = 0.05,
   } = $props();
 
   let xTicks = $state([]);
@@ -480,6 +482,8 @@
             {showGridlines}
             {labelFormatter}
             {niceTicks}
+            {leftPad}
+            {rightPad}
           ></Axis>
         {/if}
         {#if showAverage}
@@ -579,6 +583,8 @@
       {showGridlines}
       {labelFormatter}
       {niceTicks}
+      {leftPad}
+      {rightPad}
     ></Axis>
   {/if}
 </div>

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -97,11 +97,12 @@
       return tick;
     },
     niceTicks = true,
-    leftPad = 0.1,
-    rightPad = 0.05,
+    leftPad = 0,
+    rightPad = 0,
+    xTicks = $bindable([[]]),
   } = $props();
 
-  let xTicks = $state([]);
+  $inspect({ leftPad, rightPad });
 
   let xTickFirst = $derived(xTicks.length ? xTicks[0] : 0);
   let xTickLast = $derived(xTicks.length ? xTicks.at(-1) : 1);
@@ -484,6 +485,7 @@
             {niceTicks}
             {leftPad}
             {rightPad}
+            {markerRadius}
           ></Axis>
         {/if}
         {#if showAverage}
@@ -585,6 +587,7 @@
       {niceTicks}
       {leftPad}
       {rightPad}
+      {markerRadius}
     ></Axis>
   {/if}
 </div>

--- a/src/lib/components/data-vis/position-chart/PositionChart.svelte
+++ b/src/lib/components/data-vis/position-chart/PositionChart.svelte
@@ -97,8 +97,6 @@
       return tick;
     },
     niceTicks = true,
-    leftPad = 0,
-    rightPad = 0,
     xTicks = $bindable([[]]),
     xRange = $bindable([[]]),
   } = $props();
@@ -483,9 +481,8 @@
             {showGridlines}
             {labelFormatter}
             {niceTicks}
-            {leftPad}
-            {rightPad}
             {markerRadius}
+            {distribution}
           ></Axis>
         {/if}
         {#if showAverage}
@@ -564,9 +561,6 @@
     ></ValueLabel>
   {/if}
 </div>
-<p>L: {leftPad}, R: {rightPad}</p>
-<p>xTicks: {xTicks}</p>
-<p>xRange: {xRange}</p>
 
 <div style="content-visibility: hidden;">
   {#if !showAxis}
@@ -589,9 +583,8 @@
       {showGridlines}
       {labelFormatter}
       {niceTicks}
-      {leftPad}
-      {rightPad}
       {markerRadius}
+      {distribution}
     ></Axis>
   {/if}
 </div>


### PR DESCRIPTION
A fairly substantial refactoring of the the `<Ticks>`/`<Axis>` code:

 - using d3's ticks functionality rather than producing it ourselves
 - two broad patterns for axes/ticks:
     - 'nice' ticks - for where you'd rather have _round numbers_ at the edges rather than _specific numbers_
     - the alternative - for where you'd rather have _specific numbers_ at the edges rather than _round numbers_
 - therefore, the domain passed up to `<PositionChart>` is no longer just the `ticksArray`, but `axisDomain`
 - also adds optional padding to prevent ticks starting at extremes - useful for labelling where outliers start
 - this requires `<Axis>` to access the distribution of the data - so that it knows whether there are outliers beyond the ticks
 
 Much more improvement still required, including getting this to work well with both X and Y axes