### PR TITLE
Refactor npm-publish workflow for tag pushes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,36 +3,26 @@
 
 name: Node.js Package
 
-permissions:
-  id-token: write
-
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903
         with:
-          node-version: 20
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
       - run: npm ci
-    #   - run: npm test
-
-  publish-npm:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org/
-          package-manager-cache: false
-      - run: npm ci
-      - run: npm --version
-      - run: npm publish
-        # env:
-        #   NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish  # Or: npm stage publish


### PR DESCRIPTION
Updated the npm-publish workflow to trigger on push tags and modified job steps.